### PR TITLE
Update key-encoder.js

### DIFF
--- a/lib/key-encoder.js
+++ b/lib/key-encoder.js
@@ -4,6 +4,9 @@ var asn1 = require('asn1.js'),
     BN = require('bn.js'),
     EC = require('elliptic').ec
 
+// compatibility with asn1
+const Buffer = require('buffer').Buffer;
+
 var ECPrivateKeyASN = asn1.define('ECPrivateKey', function() {
     this.seq().obj(
         this.key('version').int(),


### PR DESCRIPTION
Without this, it's possible for asn1 to use one definition of Buffer and key-encoder to use another.