### PR TITLE
Update dependencies.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,44 @@
+# Javascript Node CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-javascript/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      - image: circleci/node:10
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/mongo:3.4.4
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+      - run:
+          name: "Update npm"
+          command: |
+            npm install npm@latest
+            sudo rm -rf /usr/local/lib/node_modules/npm
+            sudo mv node_modules/npm /usr/local/lib/node_modules/npm
+            sudo chown -R 500:500 /usr/local/lib/node_modules/npm
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "package.json" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run: npm install
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+
+      # run tests!
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Library for encoding ECDSA private keys to PEM, DER and raw hex formats",
   "main": "index.js",
   "scripts": {
-    "test": "node test.js"
+    "test": "nyc --reporter=text node test.js"
   },
   "repository": {
     "type": "git",
@@ -52,12 +52,13 @@
   },
   "homepage": "https://github.com/blockstack/key-encoder-js",
   "dependencies": {
-    "asn1.js": "^2.2.0",
-    "bn.js": "^3.1.2",
-    "elliptic": "^5.1.0"
+    "asn1.js": "^5.0.1",
+    "bn.js": "^4.11.8",
+    "elliptic": "^6.4.1"
   },
   "devDependencies": {
-    "tape": "^4.2.0"
+    "nyc": "^13.1.0",
+    "tape": "^4.9.1"
   },
   "files": [
     "lib/",


### PR DESCRIPTION
This is part of a larger issue https://github.com/blockstack/blockstack.js/issues/582 to reduce blockstack.js bundle size. This is one of the packages creating duplicate dependencies due to old child dependencies. 

All tests pass. Coverage is at:

```
--------------------|----------|----------|----------|----------|-------------------|
File                |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
--------------------|----------|----------|----------|----------|-------------------|
All files           |    85.14 |    64.58 |      100 |    85.14 |                   |
 key-encoder-js     |      100 |      100 |      100 |      100 |                   |
  index.js          |      100 |      100 |      100 |      100 |                   |
 key-encoder-js/lib |    84.93 |    64.58 |      100 |    84.93 |                   |
  key-encoder.js    |    84.93 |    64.58 |      100 |    84.93 |... 39,144,148,159 |
--------------------|----------|----------|----------|----------|-------------------|
```