### PR TITLE
Move type packages from devDependencies to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "key-encoder",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -134,16 +134,14 @@
       "version": "4.11.5",
       "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.5.tgz",
       "integrity": "sha512-AEAZcIZga0JgVMHNtl1CprA/hXX7/wPt79AgR4XqaDt7jyj3QWYw6LPoOiznPtugDmlubUnAahMs2PFxGcQrng==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/elliptic": {
-      "version": "6.4.8",
-      "resolved": "https://registry.npmjs.org/@types/elliptic/-/elliptic-6.4.8.tgz",
-      "integrity": "sha512-1BaK+iQLH0c33RGRhE8gMbmMF1q4YUCzB4DbP7vz/Ohex0iP2NfOlJlZMDGkqu45IoMirUJe6KZfEdFtYPk1Kg==",
-      "dev": true,
+      "version": "6.4.9",
+      "resolved": "https://registry.npmjs.org/@types/elliptic/-/elliptic-6.4.9.tgz",
+      "integrity": "sha512-Mn+OyENd6YHwJKgUSyCTUDunEDFMaFpCXt52JCA00sxtzEa1ji6H0doZHL3iXhqMTo1Ob53X+Dv0s4PAJ+IVlA==",
       "requires": {
         "@types/bn.js": "*"
       }
@@ -151,8 +149,7 @@
     "@types/node": {
       "version": "10.14.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.8.tgz",
-      "integrity": "sha512-I4+DbJEhLEg4/vIy/2gkWDvXBOOtPKV9EnLhYjMoqxcRW+TTZtUftkHktz/a8suoD5mUL7m6ReLrkPvSsCQQmw==",
-      "dev": true
+      "integrity": "sha512-I4+DbJEhLEg4/vIy/2gkWDvXBOOtPKV9EnLhYjMoqxcRW+TTZtUftkHktz/a8suoD5mUL7m6ReLrkPvSsCQQmw=="
     },
     "@types/tape": {
       "version": "4.2.33",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "key-encoder",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Library for encoding ECDSA private keys to PEM, DER and raw hex formats",
   "main": "lib/index.js",
   "scripts": {
@@ -56,12 +56,13 @@
   },
   "homepage": "https://github.com/blockstack/key-encoder-js",
   "dependencies": {
+    "@types/bn.js": "^4.11.5",
+    "@types/elliptic": "^6.4.9",
     "asn1.js": "^5.0.1",
     "bn.js": "^4.11.8",
     "elliptic": "^6.4.1"
   },
   "devDependencies": {
-    "@types/elliptic": "^6.4.6",
     "@types/node": "^10.14.6",
     "@types/tape": "^4.2.33",
     "codecov": "^3.5.0",


### PR DESCRIPTION
Libs should do this so consumers don't need to install type dependencies.