### PR TITLE
Basic support for export PKCS8

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,22 +47,22 @@ var rawPrivateKey = '844055cca13efd78ce79a4c3a4c5aba5db0ebeb7ae9d56906c03d333c56
 
 ### Encoding Private Keys
 
-Encode to and from raw, PEM, and DER formats.
+Encode to and from raw, PEM (encode to 'pkcs8' and 'pkcs1'), and DER formats.
 
 #### Encoding Private Keys as PEMs
 
 ```js
-var pemPrivateKey = keyEncoder.encodePrivate(rawPrivateKey, 'raw', 'pem')
+var pemPrivateKey = keyEncoder.encodePrivate(rawPrivateKey, 'raw', 'pem', 'pkcs8') //default is 'pkcs1'
 ```
 
 Example output:
 
 ```
------BEGIN EC PRIVATE KEY-----
-MHQCAQEEIIRAVcyhPv14znmkw6TFq6XbDr63rp1WkGwD0zPFZo1boAcGBSuBBAAK
-oUQDQgAEFHt56eHdMyTO6hFf9AN7bId8c3dxMUGL+ytxPv/Q9QIye5I4YVgb1VNe
-6uAGdlJp9AT19cUiFOlyGwSqfQQKdQ==
------END EC PRIVATE KEY-----
+-----BEGIN PRIVATE KEY-----
+MIGNAgEAMBAGByqGSM49AgEGBSuBBAAKBHYwdAIBAQQghEBVzKE+/XjOeaTDpMWr
+pdsOvreunVaQbAPTM8VmjVugBwYFK4EEAAqhRANCAAQUe3np4d0zJM7qEV/0A3ts
+h3xzd3ExQYv7K3E+/9D1AjJ7kjhhWBvVU17q4AZ2Umn0BPX1xSIU6XIbBKp9BAp1
+-----END PRIVATE KEY-----
 ```
 
 #### Encoding Private Keys to DER Format

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "key-encoder",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "Library for encoding ECDSA private keys to PEM, DER and raw hex formats",
   "main": "lib/index.js",
   "scripts": {

--- a/src/key-encoder.ts
+++ b/src/key-encoder.ts
@@ -49,10 +49,10 @@ const SubjectPublicKeyInfoASN = asn1.define(
 )
 
 interface CurveOptions {
-    curveParameters: number[]
-    privatePEMOptions: { label: string }
-    publicPEMOptions: { label: string }
-    curve: EC
+    curveParameters: number[];
+    privatePEMOptions: { label: string };
+    publicPEMOptions: { label: string };
+    curve: EC;
 }
 
 const curves: { [index: string]: CurveOptions } = {
@@ -60,27 +60,27 @@ const curves: { [index: string]: CurveOptions } = {
         curveParameters: [1, 3, 132, 0, 10],
         privatePEMOptions: { label: 'EC PRIVATE KEY' },
         publicPEMOptions: { label: 'PUBLIC KEY' },
-        curve: new EC('secp256k1'),
-    },
+        curve: new EC('secp256k1')
+    }
 }
 
 interface PrivateKeyPKCS1 {
-    version: BNjs
-    privateKey: Buffer
-    parameters: number[]
+    version: BNjs;
+    privateKey: Buffer;
+    parameters: number[];
     publicKey?: {
-        unused: number
-        data: Buffer
+        unused: number;
+        data: Buffer;
     }
 }
 
 interface PrivateKeyPKCS8 {
-    version: BNjs
-    privateKey: PrivateKeyPKCS1
+    version: BNjs;
+    privateKey: PrivateKeyPKCS1;
     privateKeyAlgorithm: { ecPublicKey: number[]; curve: number[] }
 }
 
-type KeyFormat = 'raw' | 'pem' | 'der'
+type KeyFormat = 'raw' | 'pem' | 'der';
 
 export default class KeyEncoder {
     static ECPrivateKeyASN = ECPrivateKeyASN
@@ -116,13 +116,13 @@ export default class KeyEncoder {
         const privateKeyObject: PrivateKeyPKCS1 = {
             version: new BN(1),
             privateKey: Buffer.from(rawPrivateKey, 'hex'),
-            parameters: this.options.curveParameters,
+            parameters: this.options.curveParameters
         }
 
         if (rawPublicKey) {
             privateKeyObject.publicKey = {
                 unused: 0,
-                data: Buffer.from(rawPublicKey, 'hex'),
+                data: Buffer.from(rawPublicKey, 'hex')
             }
         }
 
@@ -133,11 +133,11 @@ export default class KeyEncoder {
         return {
             algorithm: {
                 id: this.algorithmID,
-                curve: this.options.curveParameters,
+                curve: this.options.curveParameters
             },
             pub: {
                 unused: 0,
-                data: Buffer.from(rawPublicKey, 'hex'),
+                data: Buffer.from(rawPublicKey, 'hex')
             },
         }
     }
@@ -171,11 +171,7 @@ export default class KeyEncoder {
             if (typeof privateKey !== 'string') {
                 throw 'private key must be a string'
             }
-            privateKeyObject = ECPrivateKeyASN.decode(
-                privateKey,
-                'pem',
-                this.options.privatePEMOptions
-            )
+            privateKeyObject = ECPrivateKeyASN.decode(privateKey, 'pem', this.options.privatePEMOptions)
         } else {
             throw 'invalid private key format'
         }
@@ -184,16 +180,10 @@ export default class KeyEncoder {
         if (destinationFormat === 'raw') {
             return privateKeyObject.privateKey.toString('hex')
         } else if (destinationFormat === 'der') {
-            return ECPrivateKeyASN.encode(privateKeyObject, 'der').toString(
-                'hex'
-            )
+            return ECPrivateKeyASN.encode(privateKeyObject, 'der').toString('hex')
         } else if (destinationFormat === 'pem') {
             return destinationFormatType === 'pkcs1'
-                ? ECPrivateKeyASN.encode(
-                      privateKeyObject,
-                      'pem',
-                      this.options.privatePEMOptions
-                  )
+                ? ECPrivateKeyASN.encode(privateKeyObject, 'pem', this.options.privatePEMOptions)
                 : ECPrivateKey8ASN.encode(
                       this.PKCS1toPKCS8(privateKeyObject),
                       'pem',
@@ -207,11 +197,7 @@ export default class KeyEncoder {
         }
     }
 
-    encodePublic(
-        publicKey: string | Buffer,
-        originalFormat: KeyFormat,
-        destinationFormat: KeyFormat
-    ): string {
+    encodePublic(publicKey: string | Buffer, originalFormat: KeyFormat, destinationFormat: KeyFormat): string {
         let publicKeyObject
 
         /* Parse the incoming public key and convert it to a public key object */
@@ -233,11 +219,7 @@ export default class KeyEncoder {
             if (typeof publicKey !== 'string') {
                 throw 'public key must be a string'
             }
-            publicKeyObject = SubjectPublicKeyInfoASN.decode(
-                publicKey,
-                'pem',
-                this.options.publicPEMOptions
-            )
+            publicKeyObject = SubjectPublicKeyInfoASN.decode(publicKey, 'pem', this.options.publicPEMOptions)
         } else {
             throw 'invalid public key format'
         }
@@ -246,16 +228,9 @@ export default class KeyEncoder {
         if (destinationFormat === 'raw') {
             return publicKeyObject.pub.data.toString('hex')
         } else if (destinationFormat === 'der') {
-            return SubjectPublicKeyInfoASN.encode(
-                publicKeyObject,
-                'der'
-            ).toString('hex')
+            return SubjectPublicKeyInfoASN.encode(publicKeyObject, 'der').toString('hex')
         } else if (destinationFormat === 'pem') {
-            return SubjectPublicKeyInfoASN.encode(
-                publicKeyObject,
-                'pem',
-                this.options.publicPEMOptions
-            )
+            return SubjectPublicKeyInfoASN.encode(publicKeyObject, 'pem', this.options.publicPEMOptions)
         } else {
             throw 'invalid destination format for public key'
         }

--- a/src/key-encoder.ts
+++ b/src/key-encoder.ts
@@ -1,189 +1,262 @@
-import { ec as EC } from 'elliptic'
+import { ec as EC } from "elliptic";
 // @ts-ignore
-import * as asn1 from 'asn1.js'
-const BN = require('bn.js')
+import * as asn1 from "asn1.js";
+const BN = require("bn.js");
 
 /**
  * Use types for the `bn.js` lib, e.g. `@types/bn.js`
  */
-type BNjs = any
+type BNjs = any;
 
-const ECPrivateKeyASN = asn1.define('ECPrivateKey', function () {
-    // @ts-ignore
-    const self = this as any
-    self.seq().obj(
-        self.key('version').int(),
-        self.key('privateKey').octstr(),
-        self.key('parameters').explicit(0).objid().optional(),
-        self.key('publicKey').explicit(1).bitstr().optional()
-    )
-})
+const ECPrivateKeyASN = asn1.define("ECPrivateKey", function () {
+  // @ts-ignore
+  const self = this as any;
+  self
+    .seq()
+    .obj(
+      self.key("version").int(),
+      self.key("privateKey").octstr(),
+      self.key("parameters").explicit(0).objid().optional(),
+      self.key("publicKey").explicit(1).bitstr().optional()
+    );
+});
 
-const SubjectPublicKeyInfoASN = asn1.define('SubjectPublicKeyInfo', function () {
+const ECPrivateKey8ASN = asn1.define("ECPrivateKey", function () {
+  // @ts-ignore
+  const self = this as any;
+  self
+    .seq()
+    .obj(
+      self.key("version").int(),
+      self
+        .key("privateKeyAlgorithm")
+        .seq()
+        .obj(self.key("ecPublicKey").objid(), self.key("curve").objid()),
+      self.key("privateKey").octstr().contains(ECPrivateKeyASN),
+      self.key("attributes").explicit(0).bitstr().optional()
+    );
+});
+
+const SubjectPublicKeyInfoASN = asn1.define(
+  "SubjectPublicKeyInfo",
+  function () {
     // @ts-ignore
-    const self = this as any
-    self.seq().obj(
-        self.key('algorithm').seq().obj(
-            self.key("id").objid(),
-            self.key("curve").objid()
-        ),
-        self.key('pub').bitstr()
-    )
-})
+    const self = this as any;
+    self
+      .seq()
+      .obj(
+        self
+          .key("algorithm")
+          .seq()
+          .obj(self.key("id").objid(), self.key("curve").objid()),
+        self.key("pub").bitstr()
+      );
+  }
+);
 
 interface CurveOptions {
-    curveParameters: number[];
-    privatePEMOptions: { label: string };
-    publicPEMOptions: { label: string };
-    curve: EC;
+  curveParameters: number[];
+  privatePEMOptions: { label: string };
+  publicPEMOptions: { label: string };
+  curve: EC;
 }
 
 const curves: { [index: string]: CurveOptions } = {
-    secp256k1: {
-        curveParameters: [1, 3, 132, 0, 10],
-        privatePEMOptions: { label: 'EC PRIVATE KEY' },
-        publicPEMOptions: { label: 'PUBLIC KEY' },
-        curve: new EC('secp256k1')
-    }
+  secp256k1: {
+    curveParameters: [1, 3, 132, 0, 10],
+    privatePEMOptions: { label: "EC PRIVATE KEY" },
+    publicPEMOptions: { label: "PUBLIC KEY" },
+    curve: new EC("secp256k1"),
+  },
+};
+
+interface PrivateKeyPKCS1 {
+  version: BNjs;
+  privateKey: Buffer;
+  parameters: number[];
+  publicKey?: {
+    unused: number;
+    data: Buffer;
+  };
 }
 
-interface PrivateKey {
-    version: BNjs;
-    privateKey: Buffer;
-    parameters: number[];
-    publicKey?: {
-        unused: number;
-        data: Buffer;
-    }
+interface PrivateKeyPKCS8 {
+  version: BNjs;
+  privateKey: PrivateKeyPKCS1;
+  privateKeyAlgorithm: { ecPublicKey: number[]; curve: number[] };
 }
 
-type KeyFormat = 'raw' | 'pem' | 'der';
+type KeyFormat = "raw" | "pem" | "der";
 
 export default class KeyEncoder {
-    static ECPrivateKeyASN = ECPrivateKeyASN
-    static SubjectPublicKeyInfoASN = SubjectPublicKeyInfoASN
+  static ECPrivateKeyASN = ECPrivateKeyASN;
+  static ECPrivateKey8ASN = ECPrivateKey8ASN;
+  static SubjectPublicKeyInfoASN = SubjectPublicKeyInfoASN;
 
-    algorithmID: number[]
-    options: CurveOptions
+  algorithmID: number[];
+  options: CurveOptions;
 
-    constructor(options: string | CurveOptions) {
-        if (typeof options === 'string') {
-            if (options !== 'secp256k1') {
-                throw new Error('Unknown curve ' + options)
-            }
-            options = curves[options]
-        }
-        this.options = options
-        this.algorithmID = [1, 2, 840, 10045, 2, 1]
+  constructor(options: string | CurveOptions) {
+    if (typeof options === "string") {
+      if (options !== "secp256k1") {
+        throw new Error("Unknown curve " + options);
+      }
+      options = curves[options];
+    }
+    this.options = options;
+    this.algorithmID = [1, 2, 840, 10045, 2, 1];
+  }
+
+  private PKCS1toPKCS8(privateKey: PrivateKeyPKCS1): PrivateKeyPKCS8 {
+    return {
+      version: new BN(0),
+      privateKey: privateKey,
+      privateKeyAlgorithm: {
+        ecPublicKey: this.algorithmID,
+        curve: privateKey.parameters,
+      },
+    };
+  }
+
+  privateKeyObject(rawPrivateKey: string, rawPublicKey: string) {
+    const privateKeyObject: PrivateKeyPKCS1 = {
+      version: new BN(1),
+      privateKey: Buffer.from(rawPrivateKey, "hex"),
+      parameters: this.options.curveParameters,
+    };
+
+    if (rawPublicKey) {
+      privateKeyObject.publicKey = {
+        unused: 0,
+        data: Buffer.from(rawPublicKey, "hex"),
+      };
     }
 
-    privateKeyObject(rawPrivateKey: string, rawPublicKey: string) {
-        const privateKeyObject: PrivateKey = {
-            version: new BN(1),
-            privateKey: Buffer.from(rawPrivateKey, 'hex'),
-            parameters: this.options.curveParameters
-        }
+    return privateKeyObject;
+  }
 
-        if (rawPublicKey) {
-            privateKeyObject.publicKey = {
-                unused: 0,
-                data: Buffer.from(rawPublicKey, 'hex')
-            }
-        }
+  publicKeyObject(rawPublicKey: string) {
+    return {
+      algorithm: {
+        id: this.algorithmID,
+        curve: this.options.curveParameters,
+      },
+      pub: {
+        unused: 0,
+        data: Buffer.from(rawPublicKey, "hex"),
+      },
+    };
+  }
 
-        return privateKeyObject
+  encodePrivate(
+    privateKey: string | Buffer,
+    originalFormat: KeyFormat,
+    destinationFormat: KeyFormat,
+    destinationFormatType: "pkcs8" | "pkcs1" = "pkcs1"
+  ): string {
+    let privateKeyObject: PrivateKeyPKCS1;
+
+    /* Parse the incoming private key and convert it to a private key object */
+    if (originalFormat === "raw") {
+      if (typeof privateKey !== "string") {
+        throw "private key must be a string";
+      }
+      let keyPair = this.options.curve.keyFromPrivate(privateKey, "hex");
+      let rawPublicKey = keyPair.getPublic("hex");
+      privateKeyObject = this.privateKeyObject(privateKey, rawPublicKey);
+    } else if (originalFormat === "der") {
+      if (typeof privateKey !== "string") {
+        // do nothing
+      } else if (typeof privateKey === "string") {
+        privateKey = Buffer.from(privateKey, "hex");
+      } else {
+        throw "private key must be a buffer or a string";
+      }
+      privateKeyObject = ECPrivateKeyASN.decode(privateKey, "der");
+    } else if (originalFormat === "pem") {
+      if (typeof privateKey !== "string") {
+        throw "private key must be a string";
+      }
+      privateKeyObject = ECPrivateKeyASN.decode(
+        privateKey,
+        "pem",
+        this.options.privatePEMOptions
+      );
+    } else {
+      throw "invalid private key format";
     }
 
-    publicKeyObject(rawPublicKey: string) {
-        return {
-            algorithm: {
-                id: this.algorithmID,
-                curve: this.options.curveParameters
-            },
-            pub: {
-                unused: 0,
-                data: Buffer.from(rawPublicKey, 'hex')
-            }
-        }
+    /* Export the private key object to the desired format */
+    if (destinationFormat === "raw") {
+      return privateKeyObject.privateKey.toString("hex");
+    } else if (destinationFormat === "der") {
+      return ECPrivateKeyASN.encode(privateKeyObject, "der").toString("hex");
+    } else if (destinationFormat === "pem") {
+      return destinationFormatType === "pkcs1"
+        ? ECPrivateKeyASN.encode(
+            privateKeyObject,
+            "pem",
+            this.options.privatePEMOptions
+          )
+        : ECPrivateKey8ASN.encode(this.PKCS1toPKCS8(privateKeyObject), "pem", {
+            ...this.options.privatePEMOptions,
+            label: "PRIVATE KEY",
+          });
+    } else {
+      throw "invalid destination format for private key";
+    }
+  }
+
+  encodePublic(
+    publicKey: string | Buffer,
+    originalFormat: KeyFormat,
+    destinationFormat: KeyFormat
+  ): string {
+    let publicKeyObject;
+
+    /* Parse the incoming public key and convert it to a public key object */
+    if (originalFormat === "raw") {
+      if (typeof publicKey !== "string") {
+        throw "public key must be a string";
+      }
+      publicKeyObject = this.publicKeyObject(publicKey);
+    } else if (originalFormat === "der") {
+      if (typeof publicKey !== "string") {
+        // do nothing
+      } else if (typeof publicKey === "string") {
+        publicKey = Buffer.from(publicKey, "hex");
+      } else {
+        throw "public key must be a buffer or a string";
+      }
+      publicKeyObject = SubjectPublicKeyInfoASN.decode(publicKey, "der");
+    } else if (originalFormat === "pem") {
+      if (typeof publicKey !== "string") {
+        throw "public key must be a string";
+      }
+      publicKeyObject = SubjectPublicKeyInfoASN.decode(
+        publicKey,
+        "pem",
+        this.options.publicPEMOptions
+      );
+    } else {
+      throw "invalid public key format";
     }
 
-    encodePrivate(privateKey: string | Buffer, originalFormat: KeyFormat, destinationFormat: KeyFormat): string {
-        let privateKeyObject: PrivateKey
-
-        /* Parse the incoming private key and convert it to a private key object */
-        if (originalFormat === 'raw') {
-            if (typeof privateKey !== 'string') {
-                throw 'private key must be a string'
-            }
-            let keyPair = this.options.curve.keyFromPrivate(privateKey, 'hex')
-            let rawPublicKey = keyPair.getPublic('hex')
-            privateKeyObject = this.privateKeyObject(privateKey, rawPublicKey)
-        } else if (originalFormat === 'der') {
-            if (typeof privateKey !== 'string') {
-                // do nothing
-            } else if (typeof privateKey === 'string') {
-                privateKey = Buffer.from(privateKey, 'hex')
-            } else {
-                throw 'private key must be a buffer or a string'
-            }
-            privateKeyObject = ECPrivateKeyASN.decode(privateKey, 'der')
-        } else if (originalFormat === 'pem') {
-            if (typeof privateKey !== 'string') {
-                throw 'private key must be a string'
-            }
-            privateKeyObject = ECPrivateKeyASN.decode(privateKey, 'pem', this.options.privatePEMOptions)
-        } else {
-            throw 'invalid private key format'
-        }
-
-        /* Export the private key object to the desired format */
-        if (destinationFormat === 'raw') {
-            return privateKeyObject.privateKey.toString('hex')
-        } else if (destinationFormat === 'der') {
-            return ECPrivateKeyASN.encode(privateKeyObject, 'der').toString('hex')
-        } else if (destinationFormat === 'pem') {
-            return ECPrivateKeyASN.encode(privateKeyObject, 'pem', this.options.privatePEMOptions)
-        } else {
-            throw 'invalid destination format for private key'
-        }
+    /* Export the private key object to the desired format */
+    if (destinationFormat === "raw") {
+      return publicKeyObject.pub.data.toString("hex");
+    } else if (destinationFormat === "der") {
+      return SubjectPublicKeyInfoASN.encode(publicKeyObject, "der").toString(
+        "hex"
+      );
+    } else if (destinationFormat === "pem") {
+      return SubjectPublicKeyInfoASN.encode(
+        publicKeyObject,
+        "pem",
+        this.options.publicPEMOptions
+      );
+    } else {
+      throw "invalid destination format for public key";
     }
-
-    encodePublic(publicKey: string | Buffer, originalFormat: KeyFormat, destinationFormat: KeyFormat): string {
-        let publicKeyObject
-
-        /* Parse the incoming public key and convert it to a public key object */
-        if (originalFormat === 'raw') {
-            if (typeof publicKey !== 'string') {
-                throw 'public key must be a string'
-            }
-            publicKeyObject = this.publicKeyObject(publicKey)
-        } else if (originalFormat === 'der') {
-            if (typeof publicKey !== 'string') {
-                // do nothing
-            } else if (typeof publicKey === 'string') {
-                publicKey = Buffer.from(publicKey, 'hex')
-            } else {
-                throw 'public key must be a buffer or a string'
-            }
-            publicKeyObject = SubjectPublicKeyInfoASN.decode(publicKey, 'der')
-        } else if (originalFormat === 'pem') {
-            if (typeof publicKey !== 'string') {
-                throw 'public key must be a string'
-            }
-            publicKeyObject = SubjectPublicKeyInfoASN.decode(publicKey, 'pem', this.options.publicPEMOptions)
-        } else {
-            throw 'invalid public key format'
-        }
-
-        /* Export the private key object to the desired format */
-        if (destinationFormat === 'raw') {
-            return publicKeyObject.pub.data.toString('hex')
-        } else if (destinationFormat === 'der') {
-            return SubjectPublicKeyInfoASN.encode(publicKeyObject, 'der').toString('hex')
-        } else if (destinationFormat === 'pem') {
-            return SubjectPublicKeyInfoASN.encode(publicKeyObject, 'pem', this.options.publicPEMOptions)
-        } else {
-            throw 'invalid destination format for public key'
-        }
-    }
+  }
 }

--- a/src/key-encoder.ts
+++ b/src/key-encoder.ts
@@ -33,20 +33,17 @@ const ECPrivateKey8ASN = asn1.define('ECPrivateKey', function () {
     )
 })
 
-const SubjectPublicKeyInfoASN = asn1.define(
-    'SubjectPublicKeyInfo',
-    function () {
-        // @ts-ignore
-        const self = this as any
-        self.seq().obj(
-            self
-                .key('algorithm')
-                .seq()
-                .obj(self.key('id').objid(), self.key('curve').objid()),
-            self.key('pub').bitstr()
-        )
-    }
-)
+const SubjectPublicKeyInfoASN = asn1.define('SubjectPublicKeyInfo', function () {
+    // @ts-ignore
+    const self = this as any
+    self.seq().obj(
+        self
+            .key('algorithm')
+            .seq()
+            .obj(self.key('id').objid(), self.key('curve').objid()),
+        self.key('pub').bitstr()
+    )
+})
 
 interface CurveOptions {
     curveParameters: number[];
@@ -107,7 +104,7 @@ export default class KeyEncoder {
             privateKey: privateKey,
             privateKeyAlgorithm: {
                 ecPublicKey: this.algorithmID,
-                curve: privateKey.parameters,
+                curve: privateKey.parameters
             },
         }
     }
@@ -138,7 +135,7 @@ export default class KeyEncoder {
             pub: {
                 unused: 0,
                 data: Buffer.from(rawPublicKey, 'hex')
-            },
+            }
         }
     }
 

--- a/src/key-encoder.ts
+++ b/src/key-encoder.ts
@@ -1,44 +1,44 @@
-import { ec as EC } from "elliptic";
+import { ec as EC } from 'elliptic';
 // @ts-ignore
-import * as asn1 from "asn1.js";
-const BN = require("bn.js");
+import * as asn1 from 'asn1.js';
+const BN = require('bn.js');
 
 /**
  * Use types for the `bn.js` lib, e.g. `@types/bn.js`
  */
 type BNjs = any;
 
-const ECPrivateKeyASN = asn1.define("ECPrivateKey", function () {
+const ECPrivateKeyASN = asn1.define('ECPrivateKey', function () {
   // @ts-ignore
   const self = this as any;
   self
     .seq()
     .obj(
-      self.key("version").int(),
-      self.key("privateKey").octstr(),
-      self.key("parameters").explicit(0).objid().optional(),
-      self.key("publicKey").explicit(1).bitstr().optional()
+      self.key('version').int(),
+      self.key('privateKey').octstr(),
+      self.key('parameters').explicit(0).objid().optional(),
+      self.key('publicKey').explicit(1).bitstr().optional()
     );
 });
 
-const ECPrivateKey8ASN = asn1.define("ECPrivateKey", function () {
+const ECPrivateKey8ASN = asn1.define('ECPrivateKey', function () {
   // @ts-ignore
   const self = this as any;
   self
     .seq()
     .obj(
-      self.key("version").int(),
+      self.key('version').int(),
       self
-        .key("privateKeyAlgorithm")
+        .key('privateKeyAlgorithm')
         .seq()
-        .obj(self.key("ecPublicKey").objid(), self.key("curve").objid()),
-      self.key("privateKey").octstr().contains(ECPrivateKeyASN),
-      self.key("attributes").explicit(0).bitstr().optional()
+        .obj(self.key('ecPublicKey').objid(), self.key('curve').objid()),
+      self.key('privateKey').octstr().contains(ECPrivateKeyASN),
+      self.key('attributes').explicit(0).bitstr().optional()
     );
 });
 
 const SubjectPublicKeyInfoASN = asn1.define(
-  "SubjectPublicKeyInfo",
+  'SubjectPublicKeyInfo',
   function () {
     // @ts-ignore
     const self = this as any;
@@ -46,10 +46,10 @@ const SubjectPublicKeyInfoASN = asn1.define(
       .seq()
       .obj(
         self
-          .key("algorithm")
+          .key('algorithm')
           .seq()
-          .obj(self.key("id").objid(), self.key("curve").objid()),
-        self.key("pub").bitstr()
+          .obj(self.key('id').objid(), self.key('curve').objid()),
+        self.key('pub').bitstr()
       );
   }
 );
@@ -64,9 +64,9 @@ interface CurveOptions {
 const curves: { [index: string]: CurveOptions } = {
   secp256k1: {
     curveParameters: [1, 3, 132, 0, 10],
-    privatePEMOptions: { label: "EC PRIVATE KEY" },
-    publicPEMOptions: { label: "PUBLIC KEY" },
-    curve: new EC("secp256k1"),
+    privatePEMOptions: { label: 'EC PRIVATE KEY' },
+    publicPEMOptions: { label: 'PUBLIC KEY' },
+    curve: new EC('secp256k1'),
   },
 };
 
@@ -86,7 +86,7 @@ interface PrivateKeyPKCS8 {
   privateKeyAlgorithm: { ecPublicKey: number[]; curve: number[] };
 }
 
-type KeyFormat = "raw" | "pem" | "der";
+type KeyFormat = 'raw' | 'pem' | 'der';
 
 export default class KeyEncoder {
   static ECPrivateKeyASN = ECPrivateKeyASN;
@@ -97,9 +97,9 @@ export default class KeyEncoder {
   options: CurveOptions;
 
   constructor(options: string | CurveOptions) {
-    if (typeof options === "string") {
-      if (options !== "secp256k1") {
-        throw new Error("Unknown curve " + options);
+    if (typeof options === 'string') {
+      if (options !== 'secp256k1') {
+        throw new Error('Unknown curve ' + options);
       }
       options = curves[options];
     }
@@ -121,14 +121,14 @@ export default class KeyEncoder {
   privateKeyObject(rawPrivateKey: string, rawPublicKey: string) {
     const privateKeyObject: PrivateKeyPKCS1 = {
       version: new BN(1),
-      privateKey: Buffer.from(rawPrivateKey, "hex"),
+      privateKey: Buffer.from(rawPrivateKey, 'hex'),
       parameters: this.options.curveParameters,
     };
 
     if (rawPublicKey) {
       privateKeyObject.publicKey = {
         unused: 0,
-        data: Buffer.from(rawPublicKey, "hex"),
+        data: Buffer.from(rawPublicKey, 'hex'),
       };
     }
 
@@ -143,7 +143,7 @@ export default class KeyEncoder {
       },
       pub: {
         unused: 0,
-        data: Buffer.from(rawPublicKey, "hex"),
+        data: Buffer.from(rawPublicKey, 'hex'),
       },
     };
   }
@@ -152,58 +152,58 @@ export default class KeyEncoder {
     privateKey: string | Buffer,
     originalFormat: KeyFormat,
     destinationFormat: KeyFormat,
-    destinationFormatType: "pkcs8" | "pkcs1" = "pkcs1"
+    destinationFormatType: 'pkcs8' | 'pkcs1' = 'pkcs1'
   ): string {
     let privateKeyObject: PrivateKeyPKCS1;
 
     /* Parse the incoming private key and convert it to a private key object */
-    if (originalFormat === "raw") {
-      if (typeof privateKey !== "string") {
-        throw "private key must be a string";
+    if (originalFormat === 'raw') {
+      if (typeof privateKey !== 'string') {
+        throw 'private key must be a string';
       }
-      let keyPair = this.options.curve.keyFromPrivate(privateKey, "hex");
-      let rawPublicKey = keyPair.getPublic("hex");
+      let keyPair = this.options.curve.keyFromPrivate(privateKey, 'hex');
+      let rawPublicKey = keyPair.getPublic('hex');
       privateKeyObject = this.privateKeyObject(privateKey, rawPublicKey);
-    } else if (originalFormat === "der") {
-      if (typeof privateKey !== "string") {
+    } else if (originalFormat === 'der') {
+      if (typeof privateKey !== 'string') {
         // do nothing
-      } else if (typeof privateKey === "string") {
-        privateKey = Buffer.from(privateKey, "hex");
+      } else if (typeof privateKey === 'string') {
+        privateKey = Buffer.from(privateKey, 'hex');
       } else {
-        throw "private key must be a buffer or a string";
+        throw 'private key must be a buffer or a string';
       }
-      privateKeyObject = ECPrivateKeyASN.decode(privateKey, "der");
-    } else if (originalFormat === "pem") {
-      if (typeof privateKey !== "string") {
-        throw "private key must be a string";
+      privateKeyObject = ECPrivateKeyASN.decode(privateKey, 'der');
+    } else if (originalFormat === 'pem') {
+      if (typeof privateKey !== 'string') {
+        throw 'private key must be a string';
       }
       privateKeyObject = ECPrivateKeyASN.decode(
         privateKey,
-        "pem",
+        'pem',
         this.options.privatePEMOptions
       );
     } else {
-      throw "invalid private key format";
+      throw 'invalid private key format';
     }
 
     /* Export the private key object to the desired format */
-    if (destinationFormat === "raw") {
-      return privateKeyObject.privateKey.toString("hex");
-    } else if (destinationFormat === "der") {
-      return ECPrivateKeyASN.encode(privateKeyObject, "der").toString("hex");
-    } else if (destinationFormat === "pem") {
-      return destinationFormatType === "pkcs1"
+    if (destinationFormat === 'raw') {
+      return privateKeyObject.privateKey.toString('hex');
+    } else if (destinationFormat === 'der') {
+      return ECPrivateKeyASN.encode(privateKeyObject, 'der').toString('hex');
+    } else if (destinationFormat === 'pem') {
+      return destinationFormatType === 'pkcs1'
         ? ECPrivateKeyASN.encode(
             privateKeyObject,
-            "pem",
+            'pem',
             this.options.privatePEMOptions
           )
-        : ECPrivateKey8ASN.encode(this.PKCS1toPKCS8(privateKeyObject), "pem", {
+        : ECPrivateKey8ASN.encode(this.PKCS1toPKCS8(privateKeyObject), 'pem', {
             ...this.options.privatePEMOptions,
-            label: "PRIVATE KEY",
+            label: 'PRIVATE KEY',
           });
     } else {
-      throw "invalid destination format for private key";
+      throw 'invalid destination format for private key';
     }
   }
 
@@ -215,48 +215,48 @@ export default class KeyEncoder {
     let publicKeyObject;
 
     /* Parse the incoming public key and convert it to a public key object */
-    if (originalFormat === "raw") {
-      if (typeof publicKey !== "string") {
-        throw "public key must be a string";
+    if (originalFormat === 'raw') {
+      if (typeof publicKey !== 'string') {
+        throw 'public key must be a string';
       }
       publicKeyObject = this.publicKeyObject(publicKey);
-    } else if (originalFormat === "der") {
-      if (typeof publicKey !== "string") {
+    } else if (originalFormat === 'der') {
+      if (typeof publicKey !== 'string') {
         // do nothing
-      } else if (typeof publicKey === "string") {
-        publicKey = Buffer.from(publicKey, "hex");
+      } else if (typeof publicKey === 'string') {
+        publicKey = Buffer.from(publicKey, 'hex');
       } else {
-        throw "public key must be a buffer or a string";
+        throw 'public key must be a buffer or a string';
       }
-      publicKeyObject = SubjectPublicKeyInfoASN.decode(publicKey, "der");
-    } else if (originalFormat === "pem") {
-      if (typeof publicKey !== "string") {
-        throw "public key must be a string";
+      publicKeyObject = SubjectPublicKeyInfoASN.decode(publicKey, 'der');
+    } else if (originalFormat === 'pem') {
+      if (typeof publicKey !== 'string') {
+        throw 'public key must be a string';
       }
       publicKeyObject = SubjectPublicKeyInfoASN.decode(
         publicKey,
-        "pem",
+        'pem',
         this.options.publicPEMOptions
       );
     } else {
-      throw "invalid public key format";
+      throw 'invalid public key format';
     }
 
     /* Export the private key object to the desired format */
-    if (destinationFormat === "raw") {
-      return publicKeyObject.pub.data.toString("hex");
-    } else if (destinationFormat === "der") {
-      return SubjectPublicKeyInfoASN.encode(publicKeyObject, "der").toString(
-        "hex"
+    if (destinationFormat === 'raw') {
+      return publicKeyObject.pub.data.toString('hex');
+    } else if (destinationFormat === 'der') {
+      return SubjectPublicKeyInfoASN.encode(publicKeyObject, 'der').toString(
+        'hex'
       );
-    } else if (destinationFormat === "pem") {
+    } else if (destinationFormat === 'pem') {
       return SubjectPublicKeyInfoASN.encode(
         publicKeyObject,
-        "pem",
+        'pem',
         this.options.publicPEMOptions
       );
     } else {
-      throw "invalid destination format for public key";
+      throw 'invalid destination format for public key';
     }
   }
 }

--- a/src/key-encoder.ts
+++ b/src/key-encoder.ts
@@ -1,16 +1,16 @@
-import { ec as EC } from 'elliptic';
+import { ec as EC } from 'elliptic'
 // @ts-ignore
-import * as asn1 from 'asn1.js';
-const BN = require('bn.js');
+import * as asn1 from 'asn1.js'
+const BN = require('bn.js')
 
 /**
  * Use types for the `bn.js` lib, e.g. `@types/bn.js`
  */
-type BNjs = any;
+type BNjs = any
 
 const ECPrivateKeyASN = asn1.define('ECPrivateKey', function () {
   // @ts-ignore
-  const self = this as any;
+  const self = this as any
   self
     .seq()
     .obj(
@@ -18,12 +18,12 @@ const ECPrivateKeyASN = asn1.define('ECPrivateKey', function () {
       self.key('privateKey').octstr(),
       self.key('parameters').explicit(0).objid().optional(),
       self.key('publicKey').explicit(1).bitstr().optional()
-    );
-});
+    )
+})
 
 const ECPrivateKey8ASN = asn1.define('ECPrivateKey', function () {
   // @ts-ignore
-  const self = this as any;
+  const self = this as any
   self
     .seq()
     .obj(
@@ -34,14 +34,14 @@ const ECPrivateKey8ASN = asn1.define('ECPrivateKey', function () {
         .obj(self.key('ecPublicKey').objid(), self.key('curve').objid()),
       self.key('privateKey').octstr().contains(ECPrivateKeyASN),
       self.key('attributes').explicit(0).bitstr().optional()
-    );
-});
+    )
+})
 
 const SubjectPublicKeyInfoASN = asn1.define(
   'SubjectPublicKeyInfo',
   function () {
     // @ts-ignore
-    const self = this as any;
+    const self = this as any
     self
       .seq()
       .obj(
@@ -50,15 +50,15 @@ const SubjectPublicKeyInfoASN = asn1.define(
           .seq()
           .obj(self.key('id').objid(), self.key('curve').objid()),
         self.key('pub').bitstr()
-      );
+      )
   }
-);
+)
 
 interface CurveOptions {
-  curveParameters: number[];
-  privatePEMOptions: { label: string };
-  publicPEMOptions: { label: string };
-  curve: EC;
+  curveParameters: number[]
+  privatePEMOptions: { label: string }
+  publicPEMOptions: { label: string }
+  curve: EC
 }
 
 const curves: { [index: string]: CurveOptions } = {
@@ -68,43 +68,43 @@ const curves: { [index: string]: CurveOptions } = {
     publicPEMOptions: { label: 'PUBLIC KEY' },
     curve: new EC('secp256k1'),
   },
-};
+}
 
 interface PrivateKeyPKCS1 {
-  version: BNjs;
-  privateKey: Buffer;
-  parameters: number[];
+  version: BNjs
+  privateKey: Buffer
+  parameters: number[]
   publicKey?: {
-    unused: number;
-    data: Buffer;
-  };
+    unused: number
+    data: Buffer
+  }
 }
 
 interface PrivateKeyPKCS8 {
-  version: BNjs;
-  privateKey: PrivateKeyPKCS1;
-  privateKeyAlgorithm: { ecPublicKey: number[]; curve: number[] };
+  version: BNjs
+  privateKey: PrivateKeyPKCS1
+  privateKeyAlgorithm: { ecPublicKey: number[]; curve: number[] }
 }
 
-type KeyFormat = 'raw' | 'pem' | 'der';
+type KeyFormat = 'raw' | 'pem' | 'der'
 
 export default class KeyEncoder {
-  static ECPrivateKeyASN = ECPrivateKeyASN;
-  static ECPrivateKey8ASN = ECPrivateKey8ASN;
-  static SubjectPublicKeyInfoASN = SubjectPublicKeyInfoASN;
+  static ECPrivateKeyASN = ECPrivateKeyASN
+  static ECPrivateKey8ASN = ECPrivateKey8ASN
+  static SubjectPublicKeyInfoASN = SubjectPublicKeyInfoASN
 
-  algorithmID: number[];
-  options: CurveOptions;
+  algorithmID: number[]
+  options: CurveOptions
 
   constructor(options: string | CurveOptions) {
     if (typeof options === 'string') {
       if (options !== 'secp256k1') {
-        throw new Error('Unknown curve ' + options);
+        throw new Error('Unknown curve ' + options)
       }
-      options = curves[options];
+      options = curves[options]
     }
-    this.options = options;
-    this.algorithmID = [1, 2, 840, 10045, 2, 1];
+    this.options = options
+    this.algorithmID = [1, 2, 840, 10045, 2, 1]
   }
 
   private PKCS1toPKCS8(privateKey: PrivateKeyPKCS1): PrivateKeyPKCS8 {
@@ -115,7 +115,7 @@ export default class KeyEncoder {
         ecPublicKey: this.algorithmID,
         curve: privateKey.parameters,
       },
-    };
+    }
   }
 
   privateKeyObject(rawPrivateKey: string, rawPublicKey: string) {
@@ -123,16 +123,16 @@ export default class KeyEncoder {
       version: new BN(1),
       privateKey: Buffer.from(rawPrivateKey, 'hex'),
       parameters: this.options.curveParameters,
-    };
+    }
 
     if (rawPublicKey) {
       privateKeyObject.publicKey = {
         unused: 0,
         data: Buffer.from(rawPublicKey, 'hex'),
-      };
+      }
     }
 
-    return privateKeyObject;
+    return privateKeyObject
   }
 
   publicKeyObject(rawPublicKey: string) {
@@ -145,7 +145,7 @@ export default class KeyEncoder {
         unused: 0,
         data: Buffer.from(rawPublicKey, 'hex'),
       },
-    };
+    }
   }
 
   encodePrivate(
@@ -154,43 +154,43 @@ export default class KeyEncoder {
     destinationFormat: KeyFormat,
     destinationFormatType: 'pkcs8' | 'pkcs1' = 'pkcs1'
   ): string {
-    let privateKeyObject: PrivateKeyPKCS1;
+    let privateKeyObject: PrivateKeyPKCS1
 
     /* Parse the incoming private key and convert it to a private key object */
     if (originalFormat === 'raw') {
       if (typeof privateKey !== 'string') {
-        throw 'private key must be a string';
+        throw 'private key must be a string'
       }
-      let keyPair = this.options.curve.keyFromPrivate(privateKey, 'hex');
-      let rawPublicKey = keyPair.getPublic('hex');
-      privateKeyObject = this.privateKeyObject(privateKey, rawPublicKey);
+      let keyPair = this.options.curve.keyFromPrivate(privateKey, 'hex')
+      let rawPublicKey = keyPair.getPublic('hex')
+      privateKeyObject = this.privateKeyObject(privateKey, rawPublicKey)
     } else if (originalFormat === 'der') {
       if (typeof privateKey !== 'string') {
         // do nothing
       } else if (typeof privateKey === 'string') {
-        privateKey = Buffer.from(privateKey, 'hex');
+        privateKey = Buffer.from(privateKey, 'hex')
       } else {
-        throw 'private key must be a buffer or a string';
+        throw 'private key must be a buffer or a string'
       }
-      privateKeyObject = ECPrivateKeyASN.decode(privateKey, 'der');
+      privateKeyObject = ECPrivateKeyASN.decode(privateKey, 'der')
     } else if (originalFormat === 'pem') {
       if (typeof privateKey !== 'string') {
-        throw 'private key must be a string';
+        throw 'private key must be a string'
       }
       privateKeyObject = ECPrivateKeyASN.decode(
         privateKey,
         'pem',
         this.options.privatePEMOptions
-      );
+      )
     } else {
-      throw 'invalid private key format';
+      throw 'invalid private key format'
     }
 
     /* Export the private key object to the desired format */
     if (destinationFormat === 'raw') {
-      return privateKeyObject.privateKey.toString('hex');
+      return privateKeyObject.privateKey.toString('hex')
     } else if (destinationFormat === 'der') {
-      return ECPrivateKeyASN.encode(privateKeyObject, 'der').toString('hex');
+      return ECPrivateKeyASN.encode(privateKeyObject, 'der').toString('hex')
     } else if (destinationFormat === 'pem') {
       return destinationFormatType === 'pkcs1'
         ? ECPrivateKeyASN.encode(
@@ -201,9 +201,9 @@ export default class KeyEncoder {
         : ECPrivateKey8ASN.encode(this.PKCS1toPKCS8(privateKeyObject), 'pem', {
             ...this.options.privatePEMOptions,
             label: 'PRIVATE KEY',
-          });
+          })
     } else {
-      throw 'invalid destination format for private key';
+      throw 'invalid destination format for private key'
     }
   }
 
@@ -212,51 +212,51 @@ export default class KeyEncoder {
     originalFormat: KeyFormat,
     destinationFormat: KeyFormat
   ): string {
-    let publicKeyObject;
+    let publicKeyObject
 
     /* Parse the incoming public key and convert it to a public key object */
     if (originalFormat === 'raw') {
       if (typeof publicKey !== 'string') {
-        throw 'public key must be a string';
+        throw 'public key must be a string'
       }
-      publicKeyObject = this.publicKeyObject(publicKey);
+      publicKeyObject = this.publicKeyObject(publicKey)
     } else if (originalFormat === 'der') {
       if (typeof publicKey !== 'string') {
         // do nothing
       } else if (typeof publicKey === 'string') {
-        publicKey = Buffer.from(publicKey, 'hex');
+        publicKey = Buffer.from(publicKey, 'hex')
       } else {
-        throw 'public key must be a buffer or a string';
+        throw 'public key must be a buffer or a string'
       }
-      publicKeyObject = SubjectPublicKeyInfoASN.decode(publicKey, 'der');
+      publicKeyObject = SubjectPublicKeyInfoASN.decode(publicKey, 'der')
     } else if (originalFormat === 'pem') {
       if (typeof publicKey !== 'string') {
-        throw 'public key must be a string';
+        throw 'public key must be a string'
       }
       publicKeyObject = SubjectPublicKeyInfoASN.decode(
         publicKey,
         'pem',
         this.options.publicPEMOptions
-      );
+      )
     } else {
-      throw 'invalid public key format';
+      throw 'invalid public key format'
     }
 
     /* Export the private key object to the desired format */
     if (destinationFormat === 'raw') {
-      return publicKeyObject.pub.data.toString('hex');
+      return publicKeyObject.pub.data.toString('hex')
     } else if (destinationFormat === 'der') {
       return SubjectPublicKeyInfoASN.encode(publicKeyObject, 'der').toString(
         'hex'
-      );
+      )
     } else if (destinationFormat === 'pem') {
       return SubjectPublicKeyInfoASN.encode(
         publicKeyObject,
         'pem',
         this.options.publicPEMOptions
-      );
+      )
     } else {
-      throw 'invalid destination format for public key';
+      throw 'invalid destination format for public key'
     }
   }
 }

--- a/src/key-encoder.ts
+++ b/src/key-encoder.ts
@@ -9,254 +9,255 @@ const BN = require('bn.js')
 type BNjs = any
 
 const ECPrivateKeyASN = asn1.define('ECPrivateKey', function () {
-  // @ts-ignore
-  const self = this as any
-  self
-    .seq()
-    .obj(
-      self.key('version').int(),
-      self.key('privateKey').octstr(),
-      self.key('parameters').explicit(0).objid().optional(),
-      self.key('publicKey').explicit(1).bitstr().optional()
+    // @ts-ignore
+    const self = this as any
+    self.seq().obj(
+        self.key('version').int(),
+        self.key('privateKey').octstr(),
+        self.key('parameters').explicit(0).objid().optional(),
+        self.key('publicKey').explicit(1).bitstr().optional()
     )
 })
 
 const ECPrivateKey8ASN = asn1.define('ECPrivateKey', function () {
-  // @ts-ignore
-  const self = this as any
-  self
-    .seq()
-    .obj(
-      self.key('version').int(),
-      self
-        .key('privateKeyAlgorithm')
-        .seq()
-        .obj(self.key('ecPublicKey').objid(), self.key('curve').objid()),
-      self.key('privateKey').octstr().contains(ECPrivateKeyASN),
-      self.key('attributes').explicit(0).bitstr().optional()
+    // @ts-ignore
+    const self = this as any
+    self.seq().obj(
+        self.key('version').int(),
+        self
+            .key('privateKeyAlgorithm')
+            .seq()
+            .obj(self.key('ecPublicKey').objid(), self.key('curve').objid()),
+        self.key('privateKey').octstr().contains(ECPrivateKeyASN),
+        self.key('attributes').explicit(0).bitstr().optional()
     )
 })
 
 const SubjectPublicKeyInfoASN = asn1.define(
-  'SubjectPublicKeyInfo',
-  function () {
-    // @ts-ignore
-    const self = this as any
-    self
-      .seq()
-      .obj(
-        self
-          .key('algorithm')
-          .seq()
-          .obj(self.key('id').objid(), self.key('curve').objid()),
-        self.key('pub').bitstr()
-      )
-  }
+    'SubjectPublicKeyInfo',
+    function () {
+        // @ts-ignore
+        const self = this as any
+        self.seq().obj(
+            self
+                .key('algorithm')
+                .seq()
+                .obj(self.key('id').objid(), self.key('curve').objid()),
+            self.key('pub').bitstr()
+        )
+    }
 )
 
 interface CurveOptions {
-  curveParameters: number[]
-  privatePEMOptions: { label: string }
-  publicPEMOptions: { label: string }
-  curve: EC
+    curveParameters: number[]
+    privatePEMOptions: { label: string }
+    publicPEMOptions: { label: string }
+    curve: EC
 }
 
 const curves: { [index: string]: CurveOptions } = {
-  secp256k1: {
-    curveParameters: [1, 3, 132, 0, 10],
-    privatePEMOptions: { label: 'EC PRIVATE KEY' },
-    publicPEMOptions: { label: 'PUBLIC KEY' },
-    curve: new EC('secp256k1'),
-  },
+    secp256k1: {
+        curveParameters: [1, 3, 132, 0, 10],
+        privatePEMOptions: { label: 'EC PRIVATE KEY' },
+        publicPEMOptions: { label: 'PUBLIC KEY' },
+        curve: new EC('secp256k1'),
+    },
 }
 
 interface PrivateKeyPKCS1 {
-  version: BNjs
-  privateKey: Buffer
-  parameters: number[]
-  publicKey?: {
-    unused: number
-    data: Buffer
-  }
+    version: BNjs
+    privateKey: Buffer
+    parameters: number[]
+    publicKey?: {
+        unused: number
+        data: Buffer
+    }
 }
 
 interface PrivateKeyPKCS8 {
-  version: BNjs
-  privateKey: PrivateKeyPKCS1
-  privateKeyAlgorithm: { ecPublicKey: number[]; curve: number[] }
+    version: BNjs
+    privateKey: PrivateKeyPKCS1
+    privateKeyAlgorithm: { ecPublicKey: number[]; curve: number[] }
 }
 
 type KeyFormat = 'raw' | 'pem' | 'der'
 
 export default class KeyEncoder {
-  static ECPrivateKeyASN = ECPrivateKeyASN
-  static ECPrivateKey8ASN = ECPrivateKey8ASN
-  static SubjectPublicKeyInfoASN = SubjectPublicKeyInfoASN
+    static ECPrivateKeyASN = ECPrivateKeyASN
+    static ECPrivateKey8ASN = ECPrivateKey8ASN
+    static SubjectPublicKeyInfoASN = SubjectPublicKeyInfoASN
 
-  algorithmID: number[]
-  options: CurveOptions
+    algorithmID: number[]
+    options: CurveOptions
 
-  constructor(options: string | CurveOptions) {
-    if (typeof options === 'string') {
-      if (options !== 'secp256k1') {
-        throw new Error('Unknown curve ' + options)
-      }
-      options = curves[options]
-    }
-    this.options = options
-    this.algorithmID = [1, 2, 840, 10045, 2, 1]
-  }
-
-  private PKCS1toPKCS8(privateKey: PrivateKeyPKCS1): PrivateKeyPKCS8 {
-    return {
-      version: new BN(0),
-      privateKey: privateKey,
-      privateKeyAlgorithm: {
-        ecPublicKey: this.algorithmID,
-        curve: privateKey.parameters,
-      },
-    }
-  }
-
-  privateKeyObject(rawPrivateKey: string, rawPublicKey: string) {
-    const privateKeyObject: PrivateKeyPKCS1 = {
-      version: new BN(1),
-      privateKey: Buffer.from(rawPrivateKey, 'hex'),
-      parameters: this.options.curveParameters,
+    constructor(options: string | CurveOptions) {
+        if (typeof options === 'string') {
+            if (options !== 'secp256k1') {
+                throw new Error('Unknown curve ' + options)
+            }
+            options = curves[options]
+        }
+        this.options = options
+        this.algorithmID = [1, 2, 840, 10045, 2, 1]
     }
 
-    if (rawPublicKey) {
-      privateKeyObject.publicKey = {
-        unused: 0,
-        data: Buffer.from(rawPublicKey, 'hex'),
-      }
+    private PKCS1toPKCS8(privateKey: PrivateKeyPKCS1): PrivateKeyPKCS8 {
+        return {
+            version: new BN(0),
+            privateKey: privateKey,
+            privateKeyAlgorithm: {
+                ecPublicKey: this.algorithmID,
+                curve: privateKey.parameters,
+            },
+        }
     }
 
-    return privateKeyObject
-  }
+    privateKeyObject(rawPrivateKey: string, rawPublicKey: string) {
+        const privateKeyObject: PrivateKeyPKCS1 = {
+            version: new BN(1),
+            privateKey: Buffer.from(rawPrivateKey, 'hex'),
+            parameters: this.options.curveParameters,
+        }
 
-  publicKeyObject(rawPublicKey: string) {
-    return {
-      algorithm: {
-        id: this.algorithmID,
-        curve: this.options.curveParameters,
-      },
-      pub: {
-        unused: 0,
-        data: Buffer.from(rawPublicKey, 'hex'),
-      },
-    }
-  }
+        if (rawPublicKey) {
+            privateKeyObject.publicKey = {
+                unused: 0,
+                data: Buffer.from(rawPublicKey, 'hex'),
+            }
+        }
 
-  encodePrivate(
-    privateKey: string | Buffer,
-    originalFormat: KeyFormat,
-    destinationFormat: KeyFormat,
-    destinationFormatType: 'pkcs8' | 'pkcs1' = 'pkcs1'
-  ): string {
-    let privateKeyObject: PrivateKeyPKCS1
-
-    /* Parse the incoming private key and convert it to a private key object */
-    if (originalFormat === 'raw') {
-      if (typeof privateKey !== 'string') {
-        throw 'private key must be a string'
-      }
-      let keyPair = this.options.curve.keyFromPrivate(privateKey, 'hex')
-      let rawPublicKey = keyPair.getPublic('hex')
-      privateKeyObject = this.privateKeyObject(privateKey, rawPublicKey)
-    } else if (originalFormat === 'der') {
-      if (typeof privateKey !== 'string') {
-        // do nothing
-      } else if (typeof privateKey === 'string') {
-        privateKey = Buffer.from(privateKey, 'hex')
-      } else {
-        throw 'private key must be a buffer or a string'
-      }
-      privateKeyObject = ECPrivateKeyASN.decode(privateKey, 'der')
-    } else if (originalFormat === 'pem') {
-      if (typeof privateKey !== 'string') {
-        throw 'private key must be a string'
-      }
-      privateKeyObject = ECPrivateKeyASN.decode(
-        privateKey,
-        'pem',
-        this.options.privatePEMOptions
-      )
-    } else {
-      throw 'invalid private key format'
+        return privateKeyObject
     }
 
-    /* Export the private key object to the desired format */
-    if (destinationFormat === 'raw') {
-      return privateKeyObject.privateKey.toString('hex')
-    } else if (destinationFormat === 'der') {
-      return ECPrivateKeyASN.encode(privateKeyObject, 'der').toString('hex')
-    } else if (destinationFormat === 'pem') {
-      return destinationFormatType === 'pkcs1'
-        ? ECPrivateKeyASN.encode(
-            privateKeyObject,
-            'pem',
-            this.options.privatePEMOptions
-          )
-        : ECPrivateKey8ASN.encode(this.PKCS1toPKCS8(privateKeyObject), 'pem', {
-            ...this.options.privatePEMOptions,
-            label: 'PRIVATE KEY',
-          })
-    } else {
-      throw 'invalid destination format for private key'
-    }
-  }
-
-  encodePublic(
-    publicKey: string | Buffer,
-    originalFormat: KeyFormat,
-    destinationFormat: KeyFormat
-  ): string {
-    let publicKeyObject
-
-    /* Parse the incoming public key and convert it to a public key object */
-    if (originalFormat === 'raw') {
-      if (typeof publicKey !== 'string') {
-        throw 'public key must be a string'
-      }
-      publicKeyObject = this.publicKeyObject(publicKey)
-    } else if (originalFormat === 'der') {
-      if (typeof publicKey !== 'string') {
-        // do nothing
-      } else if (typeof publicKey === 'string') {
-        publicKey = Buffer.from(publicKey, 'hex')
-      } else {
-        throw 'public key must be a buffer or a string'
-      }
-      publicKeyObject = SubjectPublicKeyInfoASN.decode(publicKey, 'der')
-    } else if (originalFormat === 'pem') {
-      if (typeof publicKey !== 'string') {
-        throw 'public key must be a string'
-      }
-      publicKeyObject = SubjectPublicKeyInfoASN.decode(
-        publicKey,
-        'pem',
-        this.options.publicPEMOptions
-      )
-    } else {
-      throw 'invalid public key format'
+    publicKeyObject(rawPublicKey: string) {
+        return {
+            algorithm: {
+                id: this.algorithmID,
+                curve: this.options.curveParameters,
+            },
+            pub: {
+                unused: 0,
+                data: Buffer.from(rawPublicKey, 'hex'),
+            },
+        }
     }
 
-    /* Export the private key object to the desired format */
-    if (destinationFormat === 'raw') {
-      return publicKeyObject.pub.data.toString('hex')
-    } else if (destinationFormat === 'der') {
-      return SubjectPublicKeyInfoASN.encode(publicKeyObject, 'der').toString(
-        'hex'
-      )
-    } else if (destinationFormat === 'pem') {
-      return SubjectPublicKeyInfoASN.encode(
-        publicKeyObject,
-        'pem',
-        this.options.publicPEMOptions
-      )
-    } else {
-      throw 'invalid destination format for public key'
+    encodePrivate(
+        privateKey: string | Buffer,
+        originalFormat: KeyFormat,
+        destinationFormat: KeyFormat,
+        destinationFormatType: 'pkcs8' | 'pkcs1' = 'pkcs1'
+    ): string {
+        let privateKeyObject: PrivateKeyPKCS1
+
+        /* Parse the incoming private key and convert it to a private key object */
+        if (originalFormat === 'raw') {
+            if (typeof privateKey !== 'string') {
+                throw 'private key must be a string'
+            }
+            let keyPair = this.options.curve.keyFromPrivate(privateKey, 'hex')
+            let rawPublicKey = keyPair.getPublic('hex')
+            privateKeyObject = this.privateKeyObject(privateKey, rawPublicKey)
+        } else if (originalFormat === 'der') {
+            if (typeof privateKey !== 'string') {
+                // do nothing
+            } else if (typeof privateKey === 'string') {
+                privateKey = Buffer.from(privateKey, 'hex')
+            } else {
+                throw 'private key must be a buffer or a string'
+            }
+            privateKeyObject = ECPrivateKeyASN.decode(privateKey, 'der')
+        } else if (originalFormat === 'pem') {
+            if (typeof privateKey !== 'string') {
+                throw 'private key must be a string'
+            }
+            privateKeyObject = ECPrivateKeyASN.decode(
+                privateKey,
+                'pem',
+                this.options.privatePEMOptions
+            )
+        } else {
+            throw 'invalid private key format'
+        }
+
+        /* Export the private key object to the desired format */
+        if (destinationFormat === 'raw') {
+            return privateKeyObject.privateKey.toString('hex')
+        } else if (destinationFormat === 'der') {
+            return ECPrivateKeyASN.encode(privateKeyObject, 'der').toString(
+                'hex'
+            )
+        } else if (destinationFormat === 'pem') {
+            return destinationFormatType === 'pkcs1'
+                ? ECPrivateKeyASN.encode(
+                      privateKeyObject,
+                      'pem',
+                      this.options.privatePEMOptions
+                  )
+                : ECPrivateKey8ASN.encode(
+                      this.PKCS1toPKCS8(privateKeyObject),
+                      'pem',
+                      {
+                          ...this.options.privatePEMOptions,
+                          label: 'PRIVATE KEY',
+                      }
+                  )
+        } else {
+            throw 'invalid destination format for private key'
+        }
     }
-  }
+
+    encodePublic(
+        publicKey: string | Buffer,
+        originalFormat: KeyFormat,
+        destinationFormat: KeyFormat
+    ): string {
+        let publicKeyObject
+
+        /* Parse the incoming public key and convert it to a public key object */
+        if (originalFormat === 'raw') {
+            if (typeof publicKey !== 'string') {
+                throw 'public key must be a string'
+            }
+            publicKeyObject = this.publicKeyObject(publicKey)
+        } else if (originalFormat === 'der') {
+            if (typeof publicKey !== 'string') {
+                // do nothing
+            } else if (typeof publicKey === 'string') {
+                publicKey = Buffer.from(publicKey, 'hex')
+            } else {
+                throw 'public key must be a buffer or a string'
+            }
+            publicKeyObject = SubjectPublicKeyInfoASN.decode(publicKey, 'der')
+        } else if (originalFormat === 'pem') {
+            if (typeof publicKey !== 'string') {
+                throw 'public key must be a string'
+            }
+            publicKeyObject = SubjectPublicKeyInfoASN.decode(
+                publicKey,
+                'pem',
+                this.options.publicPEMOptions
+            )
+        } else {
+            throw 'invalid public key format'
+        }
+
+        /* Export the private key object to the desired format */
+        if (destinationFormat === 'raw') {
+            return publicKeyObject.pub.data.toString('hex')
+        } else if (destinationFormat === 'der') {
+            return SubjectPublicKeyInfoASN.encode(
+                publicKeyObject,
+                'der'
+            ).toString('hex')
+        } else if (destinationFormat === 'pem') {
+            return SubjectPublicKeyInfoASN.encode(
+                publicKeyObject,
+                'pem',
+                this.options.publicPEMOptions
+            )
+        } else {
+            throw 'invalid destination format for public key'
+        }
+    }
 }

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,10 +1,10 @@
-import * as test from 'tape';
+import * as test from 'tape'
 // @ts-ignore
-import * as BN from 'bn.js';
-import KeyEncoder from './index';
-const ECPrivateKeyASN = KeyEncoder.ECPrivateKeyASN;
-const ECPrivateKey8ASN = KeyEncoder.ECPrivateKey8ASN;
-const SubjectPublicKeyInfoASN = KeyEncoder.SubjectPublicKeyInfoASN;
+import * as BN from 'bn.js'
+import KeyEncoder from './index'
+const ECPrivateKeyASN = KeyEncoder.ECPrivateKeyASN
+const ECPrivateKey8ASN = KeyEncoder.ECPrivateKey8ASN
+const SubjectPublicKeyInfoASN = KeyEncoder.SubjectPublicKeyInfoASN
 
 const keys = {
   rawPrivate:
@@ -38,74 +38,74 @@ const keys = {
     '30818d020100301006072a8648ce3d020106052b8104000a047630740201010420 844055cca13efd78ce79a4c3a4c5aba5db0ebeb7ae9d56906c03d333c5668d5ba00706052b8104000aa14403420004147b79e9e1dd3324ceea115ff4037b6c877c73777131418bfb2b713effd0f502327b923861581bd5535eeae006765269f404f5f5c52214e9721b04aa7d040a75',
   derPublic:
     '3056301006072a8648ce3d020106052b8104000a03420004147b79e9e1dd3324ceea115ff4037b6c877c73777131418bfb2b713effd0f502327b923861581bd5535eeae006765269f404f5f5c52214e9721b04aa7d040a75',
-};
+}
 
-const keyEncoder = new KeyEncoder('secp256k1');
+const keyEncoder = new KeyEncoder('secp256k1')
 
 test('encodeECPrivateKeyASN', function (t) {
   var secp256k1Parameters = [1, 3, 132, 0, 10],
-    pemOptions = { label: 'EC PRIVATE KEY' };
+    pemOptions = { label: 'EC PRIVATE KEY' }
 
   var privateKeyObject = {
     version: new BN(1),
     privateKey: Buffer.from(keys.rawPrivate, 'hex'),
     parameters: secp256k1Parameters,
     publicKey: { unused: 0, data: Buffer.from(keys.rawPublic, 'hex') },
-  };
+  }
 
   var privateKeyPEM = ECPrivateKeyASN.encode(
     privateKeyObject,
     'pem',
     pemOptions
-  );
+  )
   t.equal(
     privateKeyPEM,
     keys.pemPrivate,
     'encoded PEM private key should match the OpenSSL reference'
-  );
+  )
 
   var decodedPrivateKeyObject = ECPrivateKeyASN.decode(
     privateKeyPEM,
     'pem',
     pemOptions
-  );
+  )
   t.equal(
     JSON.stringify(privateKeyObject),
     JSON.stringify(decodedPrivateKeyObject),
     'encoded-and-decoded private key object should match the original'
-  );
+  )
 
   var openSSLPrivateKeyObject = ECPrivateKeyASN.decode(
     keys.pemPrivate,
     'pem',
     pemOptions
-  );
+  )
   t.equal(
     JSON.stringify(privateKeyObject),
     JSON.stringify(openSSLPrivateKeyObject),
     'private key object should match the one decoded from the OpenSSL PEM'
-  );
-  t.end();
-});
+  )
+  t.end()
+})
 
 test('encodeECPrivateKey8ASN', function (t) {
   var secp256k1Parameters = [1, 3, 132, 0, 10],
-    pemOptions = { label: 'PRIVATE KEY' };
+    pemOptions = { label: 'PRIVATE KEY' }
 
   var privateKey = {
     version: new BN(1),
     privateKey: Buffer.from(keys.rawPrivate, 'hex'),
     parameters: secp256k1Parameters,
     publicKey: { unused: 0, data: Buffer.from(keys.rawPublic, 'hex') },
-  };
-  var asString = JSON.stringify(privateKey);
+  }
+  var asString = JSON.stringify(privateKey)
   var test1 = Buffer.from(
     asString
       .split('')
       .map((x) => (256 + x.charCodeAt(0)).toString(16).substr(-2))
       .join(''),
     'hex'
-  );
+  )
   var privateKeyObject = {
     version: new BN(0),
     privateKeyAlgorithm: {
@@ -113,46 +113,46 @@ test('encodeECPrivateKey8ASN', function (t) {
       curve: secp256k1Parameters,
     },
     privateKey: privateKey,
-  };
+  }
 
   var privateKeyPEM = ECPrivateKey8ASN.encode(
     privateKeyObject,
     'pem',
     pemOptions
-  );
+  )
   t.equal(
     privateKeyPEM,
     keys.pemPrivatePKCS8,
     'encoded PEM private key should match the OpenSSL reference'
-  );
+  )
 
   var decodedPrivateKeyObject = ECPrivateKey8ASN.decode(
     privateKeyPEM,
     'pem',
     pemOptions
-  );
+  )
   t.equal(
     JSON.stringify(privateKeyObject),
     JSON.stringify(decodedPrivateKeyObject),
     'encoded-and-decoded private key object should match the original'
-  );
+  )
 
   var openSSLPrivateKeyObject = ECPrivateKey8ASN.decode(
     keys.pemPrivatePKCS8,
     'pem',
     pemOptions
-  );
+  )
   t.equal(
     JSON.stringify(privateKeyObject),
     JSON.stringify(openSSLPrivateKeyObject),
     'private key object should match the one decoded from the OpenSSL PEM'
-  );
-  t.end();
-});
+  )
+  t.end()
+})
 
 test('encodeSubjectPublicKeyInfoASN', function (t) {
   var secp256k1Parameters = [1, 3, 132, 0, 10],
-    pemOptions = { label: 'PUBLIC KEY' };
+    pemOptions = { label: 'PUBLIC KEY' }
 
   var publicKeyObject = {
     algorithm: {
@@ -163,132 +163,132 @@ test('encodeSubjectPublicKeyInfoASN', function (t) {
       unused: 0,
       data: Buffer.from(keys.rawPublic, 'hex'),
     },
-  };
+  }
 
   var publicKeyPEM = SubjectPublicKeyInfoASN.encode(
     publicKeyObject,
     'pem',
     pemOptions
-  );
-  t.equal(typeof publicKeyPEM, 'string');
+  )
+  t.equal(typeof publicKeyPEM, 'string')
   t.equal(
     publicKeyPEM,
     keys.pemPublic,
     'encoded PEM public key should match the OpenSSL reference'
-  );
-  t.end();
-});
+  )
+  t.end()
+})
 
 test('encodeRawPrivateKey', function (t) {
-  var privateKeyPEM = keyEncoder.encodePrivate(keys.rawPrivate, 'raw', 'pem');
-  t.equal(typeof privateKeyPEM, 'string');
+  var privateKeyPEM = keyEncoder.encodePrivate(keys.rawPrivate, 'raw', 'pem')
+  t.equal(typeof privateKeyPEM, 'string')
   t.equal(
     privateKeyPEM,
     keys.pemPrivate,
     'encoded PEM private key should match the OpenSSL reference'
-  );
+  )
 
-  var privateKeyDER = keyEncoder.encodePrivate(keys.rawPrivate, 'raw', 'der');
-  t.equal(typeof privateKeyDER, 'string');
+  var privateKeyDER = keyEncoder.encodePrivate(keys.rawPrivate, 'raw', 'der')
+  t.equal(typeof privateKeyDER, 'string')
   t.equal(
     privateKeyDER,
     keys.derPrivate,
     'encoded DER private key should match the OpenSSL reference'
-  );
-  t.end();
-});
+  )
+  t.end()
+})
 
 test('encodeDERPrivateKey', function (t) {
-  var rawPrivateKey = keyEncoder.encodePrivate(keys.derPrivate, 'der', 'raw');
-  t.equal(typeof rawPrivateKey, 'string');
+  var rawPrivateKey = keyEncoder.encodePrivate(keys.derPrivate, 'der', 'raw')
+  t.equal(typeof rawPrivateKey, 'string')
   t.equal(
     rawPrivateKey,
     keys.rawPrivate,
     'encoded raw private key should match the OpenSSL reference'
-  );
+  )
 
-  var privateKeyPEM = keyEncoder.encodePrivate(keys.derPrivate, 'der', 'pem');
-  t.equal(typeof privateKeyPEM, 'string');
+  var privateKeyPEM = keyEncoder.encodePrivate(keys.derPrivate, 'der', 'pem')
+  t.equal(typeof privateKeyPEM, 'string')
   t.equal(
     privateKeyPEM,
     keys.pemPrivate,
     'encoded PEM private key should match the OpenSSL reference'
-  );
-  t.end();
-});
+  )
+  t.end()
+})
 
 test('encodePEMPrivateKey', function (t) {
-  var rawPrivateKey = keyEncoder.encodePrivate(keys.pemPrivate, 'pem', 'raw');
-  t.equal(typeof rawPrivateKey, 'string');
+  var rawPrivateKey = keyEncoder.encodePrivate(keys.pemPrivate, 'pem', 'raw')
+  t.equal(typeof rawPrivateKey, 'string')
   t.equal(
     rawPrivateKey,
     keys.rawPrivate,
     'encoded raw private key should match the OpenSSL reference'
-  );
+  )
 
-  var privateKeyDER = keyEncoder.encodePrivate(keys.pemPrivate, 'pem', 'der');
-  t.equal(typeof privateKeyDER, 'string');
+  var privateKeyDER = keyEncoder.encodePrivate(keys.pemPrivate, 'pem', 'der')
+  t.equal(typeof privateKeyDER, 'string')
   t.equal(
     privateKeyDER,
     keys.derPrivate,
     'encoded DER private key should match the OpenSSL reference'
-  );
-  t.end();
-});
+  )
+  t.end()
+})
 
 test('encodeRawPublicKey', function (t) {
-  var publicKeyPEM = keyEncoder.encodePublic(keys.rawPublic, 'raw', 'pem');
-  t.equal(typeof publicKeyPEM, 'string');
+  var publicKeyPEM = keyEncoder.encodePublic(keys.rawPublic, 'raw', 'pem')
+  t.equal(typeof publicKeyPEM, 'string')
   t.equal(
     publicKeyPEM,
     keys.pemPublic,
     'encoded PEM public key should match the OpenSSL reference'
-  );
+  )
 
-  var publicKeyDER = keyEncoder.encodePublic(keys.rawPublic, 'raw', 'der');
-  t.equal(typeof publicKeyDER, 'string');
+  var publicKeyDER = keyEncoder.encodePublic(keys.rawPublic, 'raw', 'der')
+  t.equal(typeof publicKeyDER, 'string')
   t.equal(
     publicKeyDER,
     keys.derPublic,
     'encoded DER public key should match the OpenSSL reference'
-  );
-  t.end();
-});
+  )
+  t.end()
+})
 
 test('encodeDERPublicKey', function (t) {
-  var rawPublicKey = keyEncoder.encodePublic(keys.derPublic, 'der', 'raw');
-  t.equal(typeof rawPublicKey, 'string');
+  var rawPublicKey = keyEncoder.encodePublic(keys.derPublic, 'der', 'raw')
+  t.equal(typeof rawPublicKey, 'string')
   t.equal(
     rawPublicKey,
     keys.rawPublic,
     'encoded raw public key should match the OpenSSL reference'
-  );
+  )
 
-  var publicKeyPEM = keyEncoder.encodePublic(keys.derPublic, 'der', 'pem');
-  t.equal(typeof publicKeyPEM, 'string');
+  var publicKeyPEM = keyEncoder.encodePublic(keys.derPublic, 'der', 'pem')
+  t.equal(typeof publicKeyPEM, 'string')
   t.equal(
     publicKeyPEM,
     keys.pemPublic,
     'encoded PEM public key should match the OpenSSL reference'
-  );
-  t.end();
-});
+  )
+  t.end()
+})
 
 test('encodePEMPublicKey', function (t) {
-  var rawPublicKey = keyEncoder.encodePublic(keys.pemPublic, 'pem', 'raw');
-  t.equal(typeof rawPublicKey, 'string');
+  var rawPublicKey = keyEncoder.encodePublic(keys.pemPublic, 'pem', 'raw')
+  t.equal(typeof rawPublicKey, 'string')
   t.equal(
     rawPublicKey,
     keys.rawPublic,
     'encoded raw public key should match the OpenSSL reference'
-  );
+  )
 
-  var publicKeyDER = keyEncoder.encodePublic(keys.pemPublic, 'pem', 'der');
-  t.equal(typeof publicKeyDER, 'string');
+  var publicKeyDER = keyEncoder.encodePublic(keys.pemPublic, 'pem', 'der')
+  t.equal(typeof publicKeyDER, 'string')
   t.equal(
     publicKeyDER,
     keys.derPublic,
     'encoded DER public key should match the OpenSSL reference'
-  );
-  t.end();
-});
+  )
+  t.end()
+})

--- a/src/test.ts
+++ b/src/test.ts
@@ -7,288 +7,288 @@ const ECPrivateKey8ASN = KeyEncoder.ECPrivateKey8ASN
 const SubjectPublicKeyInfoASN = KeyEncoder.SubjectPublicKeyInfoASN
 
 const keys = {
-  rawPrivate:
-    '844055cca13efd78ce79a4c3a4c5aba5db0ebeb7ae9d56906c03d333c5668d5b',
-  rawPublic:
-    '04147b79e9e1dd3324ceea115ff4037b6c877c73777131418bfb2b713effd0f502327b923861581bd5535eeae006765269f404f5f5c52214e9721b04aa7d040a75',
-  pemPrivate:
-    '-----BEGIN EC PRIVATE KEY-----\n' +
-    'MHQCAQEEIIRAVcyhPv14znmkw6TFq6XbDr63rp1WkGwD0zPFZo1boAcGBSuBBAAK\n' +
-    'oUQDQgAEFHt56eHdMyTO6hFf9AN7bId8c3dxMUGL+ytxPv/Q9QIye5I4YVgb1VNe\n' +
-    '6uAGdlJp9AT19cUiFOlyGwSqfQQKdQ==\n' +
-    '-----END EC PRIVATE KEY-----',
-  pemPrivatePKCS8:
-    '-----BEGIN PRIVATE KEY-----\n' +
-    'MIGNAgEAMBAGByqGSM49AgEGBSuBBAAKBHYwdAIBAQQghEBVzKE+/XjOeaTDpMWr\n' +
-    'pdsOvreunVaQbAPTM8VmjVugBwYFK4EEAAqhRANCAAQUe3np4d0zJM7qEV/0A3ts\n' +
-    'h3xzd3ExQYv7K3E+/9D1AjJ7kjhhWBvVU17q4AZ2Umn0BPX1xSIU6XIbBKp9BAp1\n' +
-    '-----END PRIVATE KEY-----',
-  pemCompactPrivate:
-    '-----BEGIN EC PRIVATE KEY-----\n' +
-    'MC4CAQEEIIRAVcyhPv14znmkw6TFq6XbDr63rp1WkGwD0zPFZo1boAcGBSuBBAAK\n' +
-    '-----END EC PRIVATE KEY-----',
-  pemPublic:
-    '-----BEGIN PUBLIC KEY-----\n' +
-    'MFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEFHt56eHdMyTO6hFf9AN7bId8c3dxMUGL\n' +
-    '+ytxPv/Q9QIye5I4YVgb1VNe6uAGdlJp9AT19cUiFOlyGwSqfQQKdQ==\n' +
-    '-----END PUBLIC KEY-----',
-  derPrivate:
-    '30740201010420844055cca13efd78ce79a4c3a4c5aba5db0ebeb7ae9d56906c03d333c5668d5ba00706052b8104000aa14403420004147b79e9e1dd3324ceea115ff4037b6c877c73777131418bfb2b713effd0f502327b923861581bd5535eeae006765269f404f5f5c52214e9721b04aa7d040a75',
-  derPrivatePKCS8:
-    '30818d020100301006072a8648ce3d020106052b8104000a047630740201010420 844055cca13efd78ce79a4c3a4c5aba5db0ebeb7ae9d56906c03d333c5668d5ba00706052b8104000aa14403420004147b79e9e1dd3324ceea115ff4037b6c877c73777131418bfb2b713effd0f502327b923861581bd5535eeae006765269f404f5f5c52214e9721b04aa7d040a75',
-  derPublic:
-    '3056301006072a8648ce3d020106052b8104000a03420004147b79e9e1dd3324ceea115ff4037b6c877c73777131418bfb2b713effd0f502327b923861581bd5535eeae006765269f404f5f5c52214e9721b04aa7d040a75',
+    rawPrivate:
+        '844055cca13efd78ce79a4c3a4c5aba5db0ebeb7ae9d56906c03d333c5668d5b',
+    rawPublic:
+        '04147b79e9e1dd3324ceea115ff4037b6c877c73777131418bfb2b713effd0f502327b923861581bd5535eeae006765269f404f5f5c52214e9721b04aa7d040a75',
+    pemPrivate:
+        '-----BEGIN EC PRIVATE KEY-----\n' +
+        'MHQCAQEEIIRAVcyhPv14znmkw6TFq6XbDr63rp1WkGwD0zPFZo1boAcGBSuBBAAK\n' +
+        'oUQDQgAEFHt56eHdMyTO6hFf9AN7bId8c3dxMUGL+ytxPv/Q9QIye5I4YVgb1VNe\n' +
+        '6uAGdlJp9AT19cUiFOlyGwSqfQQKdQ==\n' +
+        '-----END EC PRIVATE KEY-----',
+    pemPrivatePKCS8:
+        '-----BEGIN PRIVATE KEY-----\n' +
+        'MIGNAgEAMBAGByqGSM49AgEGBSuBBAAKBHYwdAIBAQQghEBVzKE+/XjOeaTDpMWr\n' +
+        'pdsOvreunVaQbAPTM8VmjVugBwYFK4EEAAqhRANCAAQUe3np4d0zJM7qEV/0A3ts\n' +
+        'h3xzd3ExQYv7K3E+/9D1AjJ7kjhhWBvVU17q4AZ2Umn0BPX1xSIU6XIbBKp9BAp1\n' +
+        '-----END PRIVATE KEY-----',
+    pemCompactPrivate:
+        '-----BEGIN EC PRIVATE KEY-----\n' +
+        'MC4CAQEEIIRAVcyhPv14znmkw6TFq6XbDr63rp1WkGwD0zPFZo1boAcGBSuBBAAK\n' +
+        '-----END EC PRIVATE KEY-----',
+    pemPublic:
+        '-----BEGIN PUBLIC KEY-----\n' +
+        'MFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEFHt56eHdMyTO6hFf9AN7bId8c3dxMUGL\n' +
+        '+ytxPv/Q9QIye5I4YVgb1VNe6uAGdlJp9AT19cUiFOlyGwSqfQQKdQ==\n' +
+        '-----END PUBLIC KEY-----',
+    derPrivate:
+        '30740201010420844055cca13efd78ce79a4c3a4c5aba5db0ebeb7ae9d56906c03d333c5668d5ba00706052b8104000aa14403420004147b79e9e1dd3324ceea115ff4037b6c877c73777131418bfb2b713effd0f502327b923861581bd5535eeae006765269f404f5f5c52214e9721b04aa7d040a75',
+    derPrivatePKCS8:
+        '30818d020100301006072a8648ce3d020106052b8104000a047630740201010420 844055cca13efd78ce79a4c3a4c5aba5db0ebeb7ae9d56906c03d333c5668d5ba00706052b8104000aa14403420004147b79e9e1dd3324ceea115ff4037b6c877c73777131418bfb2b713effd0f502327b923861581bd5535eeae006765269f404f5f5c52214e9721b04aa7d040a75',
+    derPublic:
+        '3056301006072a8648ce3d020106052b8104000a03420004147b79e9e1dd3324ceea115ff4037b6c877c73777131418bfb2b713effd0f502327b923861581bd5535eeae006765269f404f5f5c52214e9721b04aa7d040a75',
 }
 
 const keyEncoder = new KeyEncoder('secp256k1')
 
 test('encodeECPrivateKeyASN', function (t) {
-  var secp256k1Parameters = [1, 3, 132, 0, 10],
-    pemOptions = { label: 'EC PRIVATE KEY' }
+    var secp256k1Parameters = [1, 3, 132, 0, 10],
+        pemOptions = { label: 'EC PRIVATE KEY' }
 
-  var privateKeyObject = {
-    version: new BN(1),
-    privateKey: Buffer.from(keys.rawPrivate, 'hex'),
-    parameters: secp256k1Parameters,
-    publicKey: { unused: 0, data: Buffer.from(keys.rawPublic, 'hex') },
-  }
+    var privateKeyObject = {
+        version: new BN(1),
+        privateKey: Buffer.from(keys.rawPrivate, 'hex'),
+        parameters: secp256k1Parameters,
+        publicKey: { unused: 0, data: Buffer.from(keys.rawPublic, 'hex') },
+    }
 
-  var privateKeyPEM = ECPrivateKeyASN.encode(
-    privateKeyObject,
-    'pem',
-    pemOptions
-  )
-  t.equal(
-    privateKeyPEM,
-    keys.pemPrivate,
-    'encoded PEM private key should match the OpenSSL reference'
-  )
+    var privateKeyPEM = ECPrivateKeyASN.encode(
+        privateKeyObject,
+        'pem',
+        pemOptions
+    )
+    t.equal(
+        privateKeyPEM,
+        keys.pemPrivate,
+        'encoded PEM private key should match the OpenSSL reference'
+    )
 
-  var decodedPrivateKeyObject = ECPrivateKeyASN.decode(
-    privateKeyPEM,
-    'pem',
-    pemOptions
-  )
-  t.equal(
-    JSON.stringify(privateKeyObject),
-    JSON.stringify(decodedPrivateKeyObject),
-    'encoded-and-decoded private key object should match the original'
-  )
+    var decodedPrivateKeyObject = ECPrivateKeyASN.decode(
+        privateKeyPEM,
+        'pem',
+        pemOptions
+    )
+    t.equal(
+        JSON.stringify(privateKeyObject),
+        JSON.stringify(decodedPrivateKeyObject),
+        'encoded-and-decoded private key object should match the original'
+    )
 
-  var openSSLPrivateKeyObject = ECPrivateKeyASN.decode(
-    keys.pemPrivate,
-    'pem',
-    pemOptions
-  )
-  t.equal(
-    JSON.stringify(privateKeyObject),
-    JSON.stringify(openSSLPrivateKeyObject),
-    'private key object should match the one decoded from the OpenSSL PEM'
-  )
-  t.end()
+    var openSSLPrivateKeyObject = ECPrivateKeyASN.decode(
+        keys.pemPrivate,
+        'pem',
+        pemOptions
+    )
+    t.equal(
+        JSON.stringify(privateKeyObject),
+        JSON.stringify(openSSLPrivateKeyObject),
+        'private key object should match the one decoded from the OpenSSL PEM'
+    )
+    t.end()
 })
 
 test('encodeECPrivateKey8ASN', function (t) {
-  var secp256k1Parameters = [1, 3, 132, 0, 10],
-    pemOptions = { label: 'PRIVATE KEY' }
+    var secp256k1Parameters = [1, 3, 132, 0, 10],
+        pemOptions = { label: 'PRIVATE KEY' }
 
-  var privateKey = {
-    version: new BN(1),
-    privateKey: Buffer.from(keys.rawPrivate, 'hex'),
-    parameters: secp256k1Parameters,
-    publicKey: { unused: 0, data: Buffer.from(keys.rawPublic, 'hex') },
-  }
-  var asString = JSON.stringify(privateKey)
-  var test1 = Buffer.from(
-    asString
-      .split('')
-      .map((x) => (256 + x.charCodeAt(0)).toString(16).substr(-2))
-      .join(''),
-    'hex'
-  )
-  var privateKeyObject = {
-    version: new BN(0),
-    privateKeyAlgorithm: {
-      ecPublicKey: [1, 2, 840, 10045, 2, 1],
-      curve: secp256k1Parameters,
-    },
-    privateKey: privateKey,
-  }
+    var privateKey = {
+        version: new BN(1),
+        privateKey: Buffer.from(keys.rawPrivate, 'hex'),
+        parameters: secp256k1Parameters,
+        publicKey: { unused: 0, data: Buffer.from(keys.rawPublic, 'hex') },
+    }
+    var asString = JSON.stringify(privateKey)
+    var test1 = Buffer.from(
+        asString
+            .split('')
+            .map((x) => (256 + x.charCodeAt(0)).toString(16).substr(-2))
+            .join(''),
+        'hex'
+    )
+    var privateKeyObject = {
+        version: new BN(0),
+        privateKeyAlgorithm: {
+            ecPublicKey: [1, 2, 840, 10045, 2, 1],
+            curve: secp256k1Parameters,
+        },
+        privateKey: privateKey,
+    }
 
-  var privateKeyPEM = ECPrivateKey8ASN.encode(
-    privateKeyObject,
-    'pem',
-    pemOptions
-  )
-  t.equal(
-    privateKeyPEM,
-    keys.pemPrivatePKCS8,
-    'encoded PEM private key should match the OpenSSL reference'
-  )
+    var privateKeyPEM = ECPrivateKey8ASN.encode(
+        privateKeyObject,
+        'pem',
+        pemOptions
+    )
+    t.equal(
+        privateKeyPEM,
+        keys.pemPrivatePKCS8,
+        'encoded PEM private key should match the OpenSSL reference'
+    )
 
-  var decodedPrivateKeyObject = ECPrivateKey8ASN.decode(
-    privateKeyPEM,
-    'pem',
-    pemOptions
-  )
-  t.equal(
-    JSON.stringify(privateKeyObject),
-    JSON.stringify(decodedPrivateKeyObject),
-    'encoded-and-decoded private key object should match the original'
-  )
+    var decodedPrivateKeyObject = ECPrivateKey8ASN.decode(
+        privateKeyPEM,
+        'pem',
+        pemOptions
+    )
+    t.equal(
+        JSON.stringify(privateKeyObject),
+        JSON.stringify(decodedPrivateKeyObject),
+        'encoded-and-decoded private key object should match the original'
+    )
 
-  var openSSLPrivateKeyObject = ECPrivateKey8ASN.decode(
-    keys.pemPrivatePKCS8,
-    'pem',
-    pemOptions
-  )
-  t.equal(
-    JSON.stringify(privateKeyObject),
-    JSON.stringify(openSSLPrivateKeyObject),
-    'private key object should match the one decoded from the OpenSSL PEM'
-  )
-  t.end()
+    var openSSLPrivateKeyObject = ECPrivateKey8ASN.decode(
+        keys.pemPrivatePKCS8,
+        'pem',
+        pemOptions
+    )
+    t.equal(
+        JSON.stringify(privateKeyObject),
+        JSON.stringify(openSSLPrivateKeyObject),
+        'private key object should match the one decoded from the OpenSSL PEM'
+    )
+    t.end()
 })
 
 test('encodeSubjectPublicKeyInfoASN', function (t) {
-  var secp256k1Parameters = [1, 3, 132, 0, 10],
-    pemOptions = { label: 'PUBLIC KEY' }
+    var secp256k1Parameters = [1, 3, 132, 0, 10],
+        pemOptions = { label: 'PUBLIC KEY' }
 
-  var publicKeyObject = {
-    algorithm: {
-      id: [1, 2, 840, 10045, 2, 1],
-      curve: secp256k1Parameters,
-    },
-    pub: {
-      unused: 0,
-      data: Buffer.from(keys.rawPublic, 'hex'),
-    },
-  }
+    var publicKeyObject = {
+        algorithm: {
+            id: [1, 2, 840, 10045, 2, 1],
+            curve: secp256k1Parameters,
+        },
+        pub: {
+            unused: 0,
+            data: Buffer.from(keys.rawPublic, 'hex'),
+        },
+    }
 
-  var publicKeyPEM = SubjectPublicKeyInfoASN.encode(
-    publicKeyObject,
-    'pem',
-    pemOptions
-  )
-  t.equal(typeof publicKeyPEM, 'string')
-  t.equal(
-    publicKeyPEM,
-    keys.pemPublic,
-    'encoded PEM public key should match the OpenSSL reference'
-  )
-  t.end()
+    var publicKeyPEM = SubjectPublicKeyInfoASN.encode(
+        publicKeyObject,
+        'pem',
+        pemOptions
+    )
+    t.equal(typeof publicKeyPEM, 'string')
+    t.equal(
+        publicKeyPEM,
+        keys.pemPublic,
+        'encoded PEM public key should match the OpenSSL reference'
+    )
+    t.end()
 })
 
 test('encodeRawPrivateKey', function (t) {
-  var privateKeyPEM = keyEncoder.encodePrivate(keys.rawPrivate, 'raw', 'pem')
-  t.equal(typeof privateKeyPEM, 'string')
-  t.equal(
-    privateKeyPEM,
-    keys.pemPrivate,
-    'encoded PEM private key should match the OpenSSL reference'
-  )
+    var privateKeyPEM = keyEncoder.encodePrivate(keys.rawPrivate, 'raw', 'pem')
+    t.equal(typeof privateKeyPEM, 'string')
+    t.equal(
+        privateKeyPEM,
+        keys.pemPrivate,
+        'encoded PEM private key should match the OpenSSL reference'
+    )
 
-  var privateKeyDER = keyEncoder.encodePrivate(keys.rawPrivate, 'raw', 'der')
-  t.equal(typeof privateKeyDER, 'string')
-  t.equal(
-    privateKeyDER,
-    keys.derPrivate,
-    'encoded DER private key should match the OpenSSL reference'
-  )
-  t.end()
+    var privateKeyDER = keyEncoder.encodePrivate(keys.rawPrivate, 'raw', 'der')
+    t.equal(typeof privateKeyDER, 'string')
+    t.equal(
+        privateKeyDER,
+        keys.derPrivate,
+        'encoded DER private key should match the OpenSSL reference'
+    )
+    t.end()
 })
 
 test('encodeDERPrivateKey', function (t) {
-  var rawPrivateKey = keyEncoder.encodePrivate(keys.derPrivate, 'der', 'raw')
-  t.equal(typeof rawPrivateKey, 'string')
-  t.equal(
-    rawPrivateKey,
-    keys.rawPrivate,
-    'encoded raw private key should match the OpenSSL reference'
-  )
+    var rawPrivateKey = keyEncoder.encodePrivate(keys.derPrivate, 'der', 'raw')
+    t.equal(typeof rawPrivateKey, 'string')
+    t.equal(
+        rawPrivateKey,
+        keys.rawPrivate,
+        'encoded raw private key should match the OpenSSL reference'
+    )
 
-  var privateKeyPEM = keyEncoder.encodePrivate(keys.derPrivate, 'der', 'pem')
-  t.equal(typeof privateKeyPEM, 'string')
-  t.equal(
-    privateKeyPEM,
-    keys.pemPrivate,
-    'encoded PEM private key should match the OpenSSL reference'
-  )
-  t.end()
+    var privateKeyPEM = keyEncoder.encodePrivate(keys.derPrivate, 'der', 'pem')
+    t.equal(typeof privateKeyPEM, 'string')
+    t.equal(
+        privateKeyPEM,
+        keys.pemPrivate,
+        'encoded PEM private key should match the OpenSSL reference'
+    )
+    t.end()
 })
 
 test('encodePEMPrivateKey', function (t) {
-  var rawPrivateKey = keyEncoder.encodePrivate(keys.pemPrivate, 'pem', 'raw')
-  t.equal(typeof rawPrivateKey, 'string')
-  t.equal(
-    rawPrivateKey,
-    keys.rawPrivate,
-    'encoded raw private key should match the OpenSSL reference'
-  )
+    var rawPrivateKey = keyEncoder.encodePrivate(keys.pemPrivate, 'pem', 'raw')
+    t.equal(typeof rawPrivateKey, 'string')
+    t.equal(
+        rawPrivateKey,
+        keys.rawPrivate,
+        'encoded raw private key should match the OpenSSL reference'
+    )
 
-  var privateKeyDER = keyEncoder.encodePrivate(keys.pemPrivate, 'pem', 'der')
-  t.equal(typeof privateKeyDER, 'string')
-  t.equal(
-    privateKeyDER,
-    keys.derPrivate,
-    'encoded DER private key should match the OpenSSL reference'
-  )
-  t.end()
+    var privateKeyDER = keyEncoder.encodePrivate(keys.pemPrivate, 'pem', 'der')
+    t.equal(typeof privateKeyDER, 'string')
+    t.equal(
+        privateKeyDER,
+        keys.derPrivate,
+        'encoded DER private key should match the OpenSSL reference'
+    )
+    t.end()
 })
 
 test('encodeRawPublicKey', function (t) {
-  var publicKeyPEM = keyEncoder.encodePublic(keys.rawPublic, 'raw', 'pem')
-  t.equal(typeof publicKeyPEM, 'string')
-  t.equal(
-    publicKeyPEM,
-    keys.pemPublic,
-    'encoded PEM public key should match the OpenSSL reference'
-  )
+    var publicKeyPEM = keyEncoder.encodePublic(keys.rawPublic, 'raw', 'pem')
+    t.equal(typeof publicKeyPEM, 'string')
+    t.equal(
+        publicKeyPEM,
+        keys.pemPublic,
+        'encoded PEM public key should match the OpenSSL reference'
+    )
 
-  var publicKeyDER = keyEncoder.encodePublic(keys.rawPublic, 'raw', 'der')
-  t.equal(typeof publicKeyDER, 'string')
-  t.equal(
-    publicKeyDER,
-    keys.derPublic,
-    'encoded DER public key should match the OpenSSL reference'
-  )
-  t.end()
+    var publicKeyDER = keyEncoder.encodePublic(keys.rawPublic, 'raw', 'der')
+    t.equal(typeof publicKeyDER, 'string')
+    t.equal(
+        publicKeyDER,
+        keys.derPublic,
+        'encoded DER public key should match the OpenSSL reference'
+    )
+    t.end()
 })
 
 test('encodeDERPublicKey', function (t) {
-  var rawPublicKey = keyEncoder.encodePublic(keys.derPublic, 'der', 'raw')
-  t.equal(typeof rawPublicKey, 'string')
-  t.equal(
-    rawPublicKey,
-    keys.rawPublic,
-    'encoded raw public key should match the OpenSSL reference'
-  )
+    var rawPublicKey = keyEncoder.encodePublic(keys.derPublic, 'der', 'raw')
+    t.equal(typeof rawPublicKey, 'string')
+    t.equal(
+        rawPublicKey,
+        keys.rawPublic,
+        'encoded raw public key should match the OpenSSL reference'
+    )
 
-  var publicKeyPEM = keyEncoder.encodePublic(keys.derPublic, 'der', 'pem')
-  t.equal(typeof publicKeyPEM, 'string')
-  t.equal(
-    publicKeyPEM,
-    keys.pemPublic,
-    'encoded PEM public key should match the OpenSSL reference'
-  )
-  t.end()
+    var publicKeyPEM = keyEncoder.encodePublic(keys.derPublic, 'der', 'pem')
+    t.equal(typeof publicKeyPEM, 'string')
+    t.equal(
+        publicKeyPEM,
+        keys.pemPublic,
+        'encoded PEM public key should match the OpenSSL reference'
+    )
+    t.end()
 })
 
 test('encodePEMPublicKey', function (t) {
-  var rawPublicKey = keyEncoder.encodePublic(keys.pemPublic, 'pem', 'raw')
-  t.equal(typeof rawPublicKey, 'string')
-  t.equal(
-    rawPublicKey,
-    keys.rawPublic,
-    'encoded raw public key should match the OpenSSL reference'
-  )
+    var rawPublicKey = keyEncoder.encodePublic(keys.pemPublic, 'pem', 'raw')
+    t.equal(typeof rawPublicKey, 'string')
+    t.equal(
+        rawPublicKey,
+        keys.rawPublic,
+        'encoded raw public key should match the OpenSSL reference'
+    )
 
-  var publicKeyDER = keyEncoder.encodePublic(keys.pemPublic, 'pem', 'der')
-  t.equal(typeof publicKeyDER, 'string')
-  t.equal(
-    publicKeyDER,
-    keys.derPublic,
-    'encoded DER public key should match the OpenSSL reference'
-  )
-  t.end()
+    var publicKeyDER = keyEncoder.encodePublic(keys.pemPublic, 'pem', 'der')
+    t.equal(typeof publicKeyDER, 'string')
+    t.equal(
+        publicKeyDER,
+        keys.derPublic,
+        'encoded DER public key should match the OpenSSL reference'
+    )
+    t.end()
 })

--- a/src/test.ts
+++ b/src/test.ts
@@ -7,96 +7,63 @@ const ECPrivateKey8ASN = KeyEncoder.ECPrivateKey8ASN
 const SubjectPublicKeyInfoASN = KeyEncoder.SubjectPublicKeyInfoASN
 
 const keys = {
-    rawPrivate:
-        '844055cca13efd78ce79a4c3a4c5aba5db0ebeb7ae9d56906c03d333c5668d5b',
-    rawPublic:
-        '04147b79e9e1dd3324ceea115ff4037b6c877c73777131418bfb2b713effd0f502327b923861581bd5535eeae006765269f404f5f5c52214e9721b04aa7d040a75',
-    pemPrivate:
-        '-----BEGIN EC PRIVATE KEY-----\n' +
-        'MHQCAQEEIIRAVcyhPv14znmkw6TFq6XbDr63rp1WkGwD0zPFZo1boAcGBSuBBAAK\n' +
-        'oUQDQgAEFHt56eHdMyTO6hFf9AN7bId8c3dxMUGL+ytxPv/Q9QIye5I4YVgb1VNe\n' +
-        '6uAGdlJp9AT19cUiFOlyGwSqfQQKdQ==\n' +
-        '-----END EC PRIVATE KEY-----',
-    pemPrivatePKCS8:
-        '-----BEGIN PRIVATE KEY-----\n' +
-        'MIGNAgEAMBAGByqGSM49AgEGBSuBBAAKBHYwdAIBAQQghEBVzKE+/XjOeaTDpMWr\n' +
-        'pdsOvreunVaQbAPTM8VmjVugBwYFK4EEAAqhRANCAAQUe3np4d0zJM7qEV/0A3ts\n' +
-        'h3xzd3ExQYv7K3E+/9D1AjJ7kjhhWBvVU17q4AZ2Umn0BPX1xSIU6XIbBKp9BAp1\n' +
-        '-----END PRIVATE KEY-----',
-    pemCompactPrivate:
-        '-----BEGIN EC PRIVATE KEY-----\n' +
-        'MC4CAQEEIIRAVcyhPv14znmkw6TFq6XbDr63rp1WkGwD0zPFZo1boAcGBSuBBAAK\n' +
-        '-----END EC PRIVATE KEY-----',
-    pemPublic:
-        '-----BEGIN PUBLIC KEY-----\n' +
-        'MFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEFHt56eHdMyTO6hFf9AN7bId8c3dxMUGL\n' +
-        '+ytxPv/Q9QIye5I4YVgb1VNe6uAGdlJp9AT19cUiFOlyGwSqfQQKdQ==\n' +
-        '-----END PUBLIC KEY-----',
-    derPrivate:
-        '30740201010420844055cca13efd78ce79a4c3a4c5aba5db0ebeb7ae9d56906c03d333c5668d5ba00706052b8104000aa14403420004147b79e9e1dd3324ceea115ff4037b6c877c73777131418bfb2b713effd0f502327b923861581bd5535eeae006765269f404f5f5c52214e9721b04aa7d040a75',
-    derPrivatePKCS8:
-        '30818d020100301006072a8648ce3d020106052b8104000a047630740201010420 844055cca13efd78ce79a4c3a4c5aba5db0ebeb7ae9d56906c03d333c5668d5ba00706052b8104000aa14403420004147b79e9e1dd3324ceea115ff4037b6c877c73777131418bfb2b713effd0f502327b923861581bd5535eeae006765269f404f5f5c52214e9721b04aa7d040a75',
-    derPublic:
-        '3056301006072a8648ce3d020106052b8104000a03420004147b79e9e1dd3324ceea115ff4037b6c877c73777131418bfb2b713effd0f502327b923861581bd5535eeae006765269f404f5f5c52214e9721b04aa7d040a75',
+    rawPrivate: '844055cca13efd78ce79a4c3a4c5aba5db0ebeb7ae9d56906c03d333c5668d5b',
+    rawPublic: '04147b79e9e1dd3324ceea115ff4037b6c877c73777131418bfb2b713effd0f502327b923861581bd5535eeae006765269f404f5f5c52214e9721b04aa7d040a75',
+    pemPrivate: '-----BEGIN EC PRIVATE KEY-----\n' +
+    'MHQCAQEEIIRAVcyhPv14znmkw6TFq6XbDr63rp1WkGwD0zPFZo1boAcGBSuBBAAK\n' +
+    'oUQDQgAEFHt56eHdMyTO6hFf9AN7bId8c3dxMUGL+ytxPv/Q9QIye5I4YVgb1VNe\n' +
+    '6uAGdlJp9AT19cUiFOlyGwSqfQQKdQ==\n' +
+    '-----END EC PRIVATE KEY-----',
+    pemPrivatePKCS8: '-----BEGIN PRIVATE KEY-----\n' +
+    'MIGNAgEAMBAGByqGSM49AgEGBSuBBAAKBHYwdAIBAQQghEBVzKE+/XjOeaTDpMWr\n' +
+    'pdsOvreunVaQbAPTM8VmjVugBwYFK4EEAAqhRANCAAQUe3np4d0zJM7qEV/0A3ts\n' +
+    'h3xzd3ExQYv7K3E+/9D1AjJ7kjhhWBvVU17q4AZ2Umn0BPX1xSIU6XIbBKp9BAp1\n' +
+    '-----END PRIVATE KEY-----',
+    pemCompactPrivate: '-----BEGIN EC PRIVATE KEY-----\n' +
+    'MC4CAQEEIIRAVcyhPv14znmkw6TFq6XbDr63rp1WkGwD0zPFZo1boAcGBSuBBAAK\n' +
+    '-----END EC PRIVATE KEY-----',
+    pemPublic: '-----BEGIN PUBLIC KEY-----\n' +
+    'MFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEFHt56eHdMyTO6hFf9AN7bId8c3dxMUGL\n' +
+    '+ytxPv/Q9QIye5I4YVgb1VNe6uAGdlJp9AT19cUiFOlyGwSqfQQKdQ==\n' +
+    '-----END PUBLIC KEY-----',
+    derPrivate: '30740201010420844055cca13efd78ce79a4c3a4c5aba5db0ebeb7ae9d56906c03d333c5668d5ba00706052b8104000aa14403420004147b79e9e1dd3324ceea115ff4037b6c877c73777131418bfb2b713effd0f502327b923861581bd5535eeae006765269f404f5f5c52214e9721b04aa7d040a75',
+    derPrivatePKCS8: '30818d020100301006072a8648ce3d020106052b8104000a047630740201010420 844055cca13efd78ce79a4c3a4c5aba5db0ebeb7ae9d56906c03d333c5668d5ba00706052b8104000aa14403420004147b79e9e1dd3324ceea115ff4037b6c877c73777131418bfb2b713effd0f502327b923861581bd5535eeae006765269f404f5f5c52214e9721b04aa7d040a75',
+    derPublic: '3056301006072a8648ce3d020106052b8104000a03420004147b79e9e1dd3324ceea115ff4037b6c877c73777131418bfb2b713effd0f502327b923861581bd5535eeae006765269f404f5f5c52214e9721b04aa7d040a75',
 }
 
 const keyEncoder = new KeyEncoder('secp256k1')
 
-test('encodeECPrivateKeyASN', function (t) {
+test('encodeECPrivateKeyASN', function(t) {
     var secp256k1Parameters = [1, 3, 132, 0, 10],
-        pemOptions = { label: 'EC PRIVATE KEY' }
+        pemOptions = {label: 'EC PRIVATE KEY'}
 
     var privateKeyObject = {
         version: new BN(1),
         privateKey: Buffer.from(keys.rawPrivate, 'hex'),
         parameters: secp256k1Parameters,
-        publicKey: { unused: 0, data: Buffer.from(keys.rawPublic, 'hex') },
+        publicKey: { unused: 0, data: Buffer.from(keys.rawPublic, 'hex') }
     }
 
-    var privateKeyPEM = ECPrivateKeyASN.encode(
-        privateKeyObject,
-        'pem',
-        pemOptions
-    )
-    t.equal(
-        privateKeyPEM,
-        keys.pemPrivate,
-        'encoded PEM private key should match the OpenSSL reference'
-    )
+    var privateKeyPEM = ECPrivateKeyASN.encode(privateKeyObject, 'pem', pemOptions)
+    t.equal(privateKeyPEM, keys.pemPrivate, 'encoded PEM private key should match the OpenSSL reference')
 
-    var decodedPrivateKeyObject = ECPrivateKeyASN.decode(
-        privateKeyPEM,
-        'pem',
-        pemOptions
-    )
-    t.equal(
-        JSON.stringify(privateKeyObject),
-        JSON.stringify(decodedPrivateKeyObject),
-        'encoded-and-decoded private key object should match the original'
-    )
+    var decodedPrivateKeyObject = ECPrivateKeyASN.decode(privateKeyPEM, 'pem', pemOptions)
+    t.equal(JSON.stringify(privateKeyObject), JSON.stringify(decodedPrivateKeyObject), 'encoded-and-decoded private key object should match the original')
 
-    var openSSLPrivateKeyObject = ECPrivateKeyASN.decode(
-        keys.pemPrivate,
-        'pem',
-        pemOptions
-    )
-    t.equal(
-        JSON.stringify(privateKeyObject),
-        JSON.stringify(openSSLPrivateKeyObject),
-        'private key object should match the one decoded from the OpenSSL PEM'
-    )
+    var openSSLPrivateKeyObject = ECPrivateKeyASN.decode(keys.pemPrivate, 'pem', pemOptions)
+    t.equal(JSON.stringify(privateKeyObject), JSON.stringify(openSSLPrivateKeyObject), 'private key object should match the one decoded from the OpenSSL PEM')
     t.end()
 })
 
-test('encodeECPrivateKey8ASN', function (t) {
+test('encodeECPrivateKey8ASN', function(t) {
     var secp256k1Parameters = [1, 3, 132, 0, 10],
-        pemOptions = { label: 'PRIVATE KEY' }
+        pemOptions = {label: 'PRIVATE KEY'}
 
     var privateKey = {
         version: new BN(1),
         privateKey: Buffer.from(keys.rawPrivate, 'hex'),
         parameters: secp256k1Parameters,
-        publicKey: { unused: 0, data: Buffer.from(keys.rawPublic, 'hex') },
+        publicKey: { unused: 0, data: Buffer.from(keys.rawPublic, 'hex') }
     }
     var asString = JSON.stringify(privateKey)
     var test1 = Buffer.from(
@@ -115,180 +82,100 @@ test('encodeECPrivateKey8ASN', function (t) {
         privateKey: privateKey,
     }
 
-    var privateKeyPEM = ECPrivateKey8ASN.encode(
-        privateKeyObject,
-        'pem',
-        pemOptions
-    )
-    t.equal(
-        privateKeyPEM,
-        keys.pemPrivatePKCS8,
-        'encoded PEM private key should match the OpenSSL reference'
-    )
+    var privateKeyPEM = ECPrivateKey8ASN.encode(privateKeyObject, 'pem', pemOptions)
+    t.equal(privateKeyPEM, keys.pemPrivatePKCS8, 'encoded PEM private key should match the OpenSSL reference')
 
-    var decodedPrivateKeyObject = ECPrivateKey8ASN.decode(
-        privateKeyPEM,
-        'pem',
-        pemOptions
-    )
-    t.equal(
-        JSON.stringify(privateKeyObject),
-        JSON.stringify(decodedPrivateKeyObject),
-        'encoded-and-decoded private key object should match the original'
-    )
+    var decodedPrivateKeyObject = ECPrivateKey8ASN.decode(privateKeyPEM, 'pem', pemOptions)
+    t.equal(JSON.stringify(privateKeyObject), JSON.stringify(decodedPrivateKeyObject), 'encoded-and-decoded private key object should match the original')
 
-    var openSSLPrivateKeyObject = ECPrivateKey8ASN.decode(
-        keys.pemPrivatePKCS8,
-        'pem',
-        pemOptions
-    )
-    t.equal(
-        JSON.stringify(privateKeyObject),
-        JSON.stringify(openSSLPrivateKeyObject),
-        'private key object should match the one decoded from the OpenSSL PEM'
-    )
+    var openSSLPrivateKeyObject = ECPrivateKey8ASN.decode(keys.pemPrivatePKCS8,'pem',pemOptions)
+    t.equal(JSON.stringify(privateKeyObject), JSON.stringify(openSSLPrivateKeyObject), 'private key object should match the one decoded from the OpenSSL PEM')
     t.end()
 })
 
-test('encodeSubjectPublicKeyInfoASN', function (t) {
+test('encodeSubjectPublicKeyInfoASN', function(t) {
     var secp256k1Parameters = [1, 3, 132, 0, 10],
-        pemOptions = { label: 'PUBLIC KEY' }
+        pemOptions = {label: 'PUBLIC KEY'}
 
     var publicKeyObject = {
         algorithm: {
             id: [1, 2, 840, 10045, 2, 1],
-            curve: secp256k1Parameters,
+            curve: secp256k1Parameters
         },
         pub: {
             unused: 0,
-            data: Buffer.from(keys.rawPublic, 'hex'),
+            data: Buffer.from(keys.rawPublic, 'hex')
         },
     }
 
-    var publicKeyPEM = SubjectPublicKeyInfoASN.encode(
-        publicKeyObject,
-        'pem',
-        pemOptions
-    )
+    var publicKeyPEM = SubjectPublicKeyInfoASN.encode(publicKeyObject, 'pem', pemOptions)
     t.equal(typeof publicKeyPEM, 'string')
-    t.equal(
-        publicKeyPEM,
-        keys.pemPublic,
-        'encoded PEM public key should match the OpenSSL reference'
-    )
+    t.equal(publicKeyPEM, keys.pemPublic, 'encoded PEM public key should match the OpenSSL reference')
     t.end()
 })
 
-test('encodeRawPrivateKey', function (t) {
+test('encodeRawPrivateKey', function(t) {
     var privateKeyPEM = keyEncoder.encodePrivate(keys.rawPrivate, 'raw', 'pem')
     t.equal(typeof privateKeyPEM, 'string')
-    t.equal(
-        privateKeyPEM,
-        keys.pemPrivate,
-        'encoded PEM private key should match the OpenSSL reference'
-    )
+    t.equal(privateKeyPEM, keys.pemPrivate, 'encoded PEM private key should match the OpenSSL reference')
 
     var privateKeyDER = keyEncoder.encodePrivate(keys.rawPrivate, 'raw', 'der')
     t.equal(typeof privateKeyDER, 'string')
-    t.equal(
-        privateKeyDER,
-        keys.derPrivate,
-        'encoded DER private key should match the OpenSSL reference'
-    )
+    t.equal(privateKeyDER,keys.derPrivate, 'encoded DER private key should match the OpenSSL reference')
     t.end()
 })
 
-test('encodeDERPrivateKey', function (t) {
+test('encodeDERPrivateKey', function(t) {
     var rawPrivateKey = keyEncoder.encodePrivate(keys.derPrivate, 'der', 'raw')
     t.equal(typeof rawPrivateKey, 'string')
-    t.equal(
-        rawPrivateKey,
-        keys.rawPrivate,
-        'encoded raw private key should match the OpenSSL reference'
-    )
+    t.equal(rawPrivateKey, keys.rawPrivate, 'encoded raw private key should match the OpenSSL reference')
 
     var privateKeyPEM = keyEncoder.encodePrivate(keys.derPrivate, 'der', 'pem')
     t.equal(typeof privateKeyPEM, 'string')
-    t.equal(
-        privateKeyPEM,
-        keys.pemPrivate,
-        'encoded PEM private key should match the OpenSSL reference'
-    )
+    t.equal(privateKeyPEM, keys.pemPrivate, 'encoded PEM private key should match the OpenSSL reference')
     t.end()
 })
 
-test('encodePEMPrivateKey', function (t) {
+test('encodePEMPrivateKey', function(t) {
     var rawPrivateKey = keyEncoder.encodePrivate(keys.pemPrivate, 'pem', 'raw')
     t.equal(typeof rawPrivateKey, 'string')
-    t.equal(
-        rawPrivateKey,
-        keys.rawPrivate,
-        'encoded raw private key should match the OpenSSL reference'
-    )
+    t.equal(rawPrivateKey, keys.rawPrivate, 'encoded raw private key should match the OpenSSL reference')
 
     var privateKeyDER = keyEncoder.encodePrivate(keys.pemPrivate, 'pem', 'der')
     t.equal(typeof privateKeyDER, 'string')
-    t.equal(
-        privateKeyDER,
-        keys.derPrivate,
-        'encoded DER private key should match the OpenSSL reference'
-    )
+    t.equal(privateKeyDER,keys.derPrivate, 'encoded DER private key should match the OpenSSL reference')
     t.end()
 })
 
-test('encodeRawPublicKey', function (t) {
+test('encodeRawPublicKey', function(t) {
     var publicKeyPEM = keyEncoder.encodePublic(keys.rawPublic, 'raw', 'pem')
     t.equal(typeof publicKeyPEM, 'string')
-    t.equal(
-        publicKeyPEM,
-        keys.pemPublic,
-        'encoded PEM public key should match the OpenSSL reference'
-    )
+    t.equal(publicKeyPEM, keys.pemPublic, 'encoded PEM public key should match the OpenSSL reference')
 
     var publicKeyDER = keyEncoder.encodePublic(keys.rawPublic, 'raw', 'der')
     t.equal(typeof publicKeyDER, 'string')
-    t.equal(
-        publicKeyDER,
-        keys.derPublic,
-        'encoded DER public key should match the OpenSSL reference'
-    )
+    t.equal(publicKeyDER, keys.derPublic, 'encoded DER public key should match the OpenSSL reference')
     t.end()
 })
 
-test('encodeDERPublicKey', function (t) {
+test('encodeDERPublicKey', function(t) {
     var rawPublicKey = keyEncoder.encodePublic(keys.derPublic, 'der', 'raw')
     t.equal(typeof rawPublicKey, 'string')
-    t.equal(
-        rawPublicKey,
-        keys.rawPublic,
-        'encoded raw public key should match the OpenSSL reference'
-    )
+    t.equal(rawPublicKey, keys.rawPublic, 'encoded raw public key should match the OpenSSL reference')
 
     var publicKeyPEM = keyEncoder.encodePublic(keys.derPublic, 'der', 'pem')
     t.equal(typeof publicKeyPEM, 'string')
-    t.equal(
-        publicKeyPEM,
-        keys.pemPublic,
-        'encoded PEM public key should match the OpenSSL reference'
-    )
+    t.equal(publicKeyPEM, keys.pemPublic, 'encoded PEM public key should match the OpenSSL reference')
     t.end()
 })
 
-test('encodePEMPublicKey', function (t) {
+test('encodePEMPublicKey', function(t) {
     var rawPublicKey = keyEncoder.encodePublic(keys.pemPublic, 'pem', 'raw')
     t.equal(typeof rawPublicKey, 'string')
-    t.equal(
-        rawPublicKey,
-        keys.rawPublic,
-        'encoded raw public key should match the OpenSSL reference'
-    )
+    t.equal(rawPublicKey, keys.rawPublic, 'encoded raw public key should match the OpenSSL reference')
 
     var publicKeyDER = keyEncoder.encodePublic(keys.pemPublic, 'pem', 'der')
     t.equal(typeof publicKeyDER, 'string')
-    t.equal(
-        publicKeyDER,
-        keys.derPublic,
-        'encoded DER public key should match the OpenSSL reference'
-    )
+    t.equal(publicKeyDER, keys.derPublic, 'encoded DER public key should match the OpenSSL reference')
     t.end()
 })

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,137 +1,294 @@
-import * as test from 'tape'
+import * as test from "tape";
 // @ts-ignore
-import * as BN from 'bn.js'
-import KeyEncoder from './index'
-const ECPrivateKeyASN = KeyEncoder.ECPrivateKeyASN
-const SubjectPublicKeyInfoASN = KeyEncoder.SubjectPublicKeyInfoASN
-
+import * as BN from "bn.js";
+import KeyEncoder from "./index";
+const ECPrivateKeyASN = KeyEncoder.ECPrivateKeyASN;
+const ECPrivateKey8ASN = KeyEncoder.ECPrivateKey8ASN;
+const SubjectPublicKeyInfoASN = KeyEncoder.SubjectPublicKeyInfoASN;
 
 const keys = {
-    rawPrivate: '844055cca13efd78ce79a4c3a4c5aba5db0ebeb7ae9d56906c03d333c5668d5b',
-    rawPublic: '04147b79e9e1dd3324ceea115ff4037b6c877c73777131418bfb2b713effd0f502327b923861581bd5535eeae006765269f404f5f5c52214e9721b04aa7d040a75',
-    pemPrivate: '-----BEGIN EC PRIVATE KEY-----\n' +
-    'MHQCAQEEIIRAVcyhPv14znmkw6TFq6XbDr63rp1WkGwD0zPFZo1boAcGBSuBBAAK\n' +
-    'oUQDQgAEFHt56eHdMyTO6hFf9AN7bId8c3dxMUGL+ytxPv/Q9QIye5I4YVgb1VNe\n' +
-    '6uAGdlJp9AT19cUiFOlyGwSqfQQKdQ==\n' +
-    '-----END EC PRIVATE KEY-----',
-    pemCompactPrivate: '-----BEGIN EC PRIVATE KEY-----\n' +
-    'MC4CAQEEIIRAVcyhPv14znmkw6TFq6XbDr63rp1WkGwD0zPFZo1boAcGBSuBBAAK\n' +
-    '-----END EC PRIVATE KEY-----',
-    pemPublic: '-----BEGIN PUBLIC KEY-----\n' +
-    'MFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEFHt56eHdMyTO6hFf9AN7bId8c3dxMUGL\n' +
-    '+ytxPv/Q9QIye5I4YVgb1VNe6uAGdlJp9AT19cUiFOlyGwSqfQQKdQ==\n' +
-    '-----END PUBLIC KEY-----',
-    derPrivate: '30740201010420844055cca13efd78ce79a4c3a4c5aba5db0ebeb7ae9d56906c03d333c5668d5ba00706052b8104000aa14403420004147b79e9e1dd3324ceea115ff4037b6c877c73777131418bfb2b713effd0f502327b923861581bd5535eeae006765269f404f5f5c52214e9721b04aa7d040a75',
-    derPublic: '3056301006072a8648ce3d020106052b8104000a03420004147b79e9e1dd3324ceea115ff4037b6c877c73777131418bfb2b713effd0f502327b923861581bd5535eeae006765269f404f5f5c52214e9721b04aa7d040a75'
-}
+  rawPrivate:
+    "844055cca13efd78ce79a4c3a4c5aba5db0ebeb7ae9d56906c03d333c5668d5b",
+  rawPublic:
+    "04147b79e9e1dd3324ceea115ff4037b6c877c73777131418bfb2b713effd0f502327b923861581bd5535eeae006765269f404f5f5c52214e9721b04aa7d040a75",
+  pemPrivate:
+    "-----BEGIN EC PRIVATE KEY-----\n" +
+    "MHQCAQEEIIRAVcyhPv14znmkw6TFq6XbDr63rp1WkGwD0zPFZo1boAcGBSuBBAAK\n" +
+    "oUQDQgAEFHt56eHdMyTO6hFf9AN7bId8c3dxMUGL+ytxPv/Q9QIye5I4YVgb1VNe\n" +
+    "6uAGdlJp9AT19cUiFOlyGwSqfQQKdQ==\n" +
+    "-----END EC PRIVATE KEY-----",
+  pemPrivatePKCS8:
+    "-----BEGIN PRIVATE KEY-----\n" +
+    "MIGNAgEAMBAGByqGSM49AgEGBSuBBAAKBHYwdAIBAQQghEBVzKE+/XjOeaTDpMWr\n" +
+    "pdsOvreunVaQbAPTM8VmjVugBwYFK4EEAAqhRANCAAQUe3np4d0zJM7qEV/0A3ts\n" +
+    "h3xzd3ExQYv7K3E+/9D1AjJ7kjhhWBvVU17q4AZ2Umn0BPX1xSIU6XIbBKp9BAp1\n" +
+    "-----END PRIVATE KEY-----",
+  pemCompactPrivate:
+    "-----BEGIN EC PRIVATE KEY-----\n" +
+    "MC4CAQEEIIRAVcyhPv14znmkw6TFq6XbDr63rp1WkGwD0zPFZo1boAcGBSuBBAAK\n" +
+    "-----END EC PRIVATE KEY-----",
+  pemPublic:
+    "-----BEGIN PUBLIC KEY-----\n" +
+    "MFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEFHt56eHdMyTO6hFf9AN7bId8c3dxMUGL\n" +
+    "+ytxPv/Q9QIye5I4YVgb1VNe6uAGdlJp9AT19cUiFOlyGwSqfQQKdQ==\n" +
+    "-----END PUBLIC KEY-----",
+  derPrivate:
+    "30740201010420844055cca13efd78ce79a4c3a4c5aba5db0ebeb7ae9d56906c03d333c5668d5ba00706052b8104000aa14403420004147b79e9e1dd3324ceea115ff4037b6c877c73777131418bfb2b713effd0f502327b923861581bd5535eeae006765269f404f5f5c52214e9721b04aa7d040a75",
+  derPrivatePKCS8:
+    "30818d020100301006072a8648ce3d020106052b8104000a047630740201010420 844055cca13efd78ce79a4c3a4c5aba5db0ebeb7ae9d56906c03d333c5668d5ba00706052b8104000aa14403420004147b79e9e1dd3324ceea115ff4037b6c877c73777131418bfb2b713effd0f502327b923861581bd5535eeae006765269f404f5f5c52214e9721b04aa7d040a75",
+  derPublic:
+    "3056301006072a8648ce3d020106052b8104000a03420004147b79e9e1dd3324ceea115ff4037b6c877c73777131418bfb2b713effd0f502327b923861581bd5535eeae006765269f404f5f5c52214e9721b04aa7d040a75",
+};
 
-const keyEncoder = new KeyEncoder('secp256k1')
+const keyEncoder = new KeyEncoder("secp256k1");
 
-test('encodeECPrivateKeyASN', function(t) {
-    var secp256k1Parameters = [1, 3, 132, 0, 10],
-        pemOptions =  {label: 'EC PRIVATE KEY'}
+test("encodeECPrivateKeyASN", function (t) {
+  var secp256k1Parameters = [1, 3, 132, 0, 10],
+    pemOptions = { label: "EC PRIVATE KEY" };
 
-    var privateKeyObject = {
-        version: new BN(1),
-        privateKey: Buffer.from(keys.rawPrivate, 'hex'),
-        parameters: secp256k1Parameters,
-        publicKey: { unused: 0, data: Buffer.from(keys.rawPublic, 'hex') }
-    }
+  var privateKeyObject = {
+    version: new BN(1),
+    privateKey: Buffer.from(keys.rawPrivate, "hex"),
+    parameters: secp256k1Parameters,
+    publicKey: { unused: 0, data: Buffer.from(keys.rawPublic, "hex") },
+  };
 
-    var privateKeyPEM = ECPrivateKeyASN.encode(privateKeyObject, 'pem', pemOptions)
-    t.equal(privateKeyPEM, keys.pemPrivate, 'encoded PEM private key should match the OpenSSL reference')
+  var privateKeyPEM = ECPrivateKeyASN.encode(
+    privateKeyObject,
+    "pem",
+    pemOptions
+  );
+  t.equal(
+    privateKeyPEM,
+    keys.pemPrivate,
+    "encoded PEM private key should match the OpenSSL reference"
+  );
 
-    var decodedPrivateKeyObject = ECPrivateKeyASN.decode(privateKeyPEM, 'pem', pemOptions)
-    t.equal(JSON.stringify(privateKeyObject), JSON.stringify(decodedPrivateKeyObject), 'encoded-and-decoded private key object should match the original')
+  var decodedPrivateKeyObject = ECPrivateKeyASN.decode(
+    privateKeyPEM,
+    "pem",
+    pemOptions
+  );
+  t.equal(
+    JSON.stringify(privateKeyObject),
+    JSON.stringify(decodedPrivateKeyObject),
+    "encoded-and-decoded private key object should match the original"
+  );
 
-    var openSSLPrivateKeyObject = ECPrivateKeyASN.decode(keys.pemPrivate, 'pem', pemOptions)
-    t.equal(JSON.stringify(privateKeyObject), JSON.stringify(openSSLPrivateKeyObject), 'private key object should match the one decoded from the OpenSSL PEM')
-    t.end()
-})
+  var openSSLPrivateKeyObject = ECPrivateKeyASN.decode(
+    keys.pemPrivate,
+    "pem",
+    pemOptions
+  );
+  t.equal(
+    JSON.stringify(privateKeyObject),
+    JSON.stringify(openSSLPrivateKeyObject),
+    "private key object should match the one decoded from the OpenSSL PEM"
+  );
+  t.end();
+});
 
-test('encodeSubjectPublicKeyInfoASN', function(t) {
-    var secp256k1Parameters = [1, 3, 132, 0, 10],
-        pemOptions =  {label: 'PUBLIC KEY'}
+test("encodeECPrivateKey8ASN", function (t) {
+  var secp256k1Parameters = [1, 3, 132, 0, 10],
+    pemOptions = { label: "PRIVATE KEY" };
 
-    var publicKeyObject = {
-        algorithm: {
-            id: [1, 2, 840, 10045, 2, 1],
-            curve: secp256k1Parameters
-        },
-        pub: {
-            unused: 0,
-            data: Buffer.from(keys.rawPublic, 'hex')
-        }
-    }
+  var privateKey = {
+    version: new BN(1),
+    privateKey: Buffer.from(keys.rawPrivate, "hex"),
+    parameters: secp256k1Parameters,
+    publicKey: { unused: 0, data: Buffer.from(keys.rawPublic, "hex") },
+  };
+  var asString = JSON.stringify(privateKey);
+  var test1 = Buffer.from(
+    asString
+      .split("")
+      .map((x) => (256 + x.charCodeAt(0)).toString(16).substr(-2))
+      .join(""),
+    "hex"
+  );
+  var privateKeyObject = {
+    version: new BN(0),
+    privateKeyAlgorithm: {
+      ecPublicKey: [1, 2, 840, 10045, 2, 1],
+      curve: secp256k1Parameters,
+    },
+    privateKey: privateKey,
+  };
 
-    var publicKeyPEM = SubjectPublicKeyInfoASN.encode(publicKeyObject, 'pem', pemOptions)
-    t.equal(typeof publicKeyPEM, "string")
-    t.equal(publicKeyPEM, keys.pemPublic, 'encoded PEM public key should match the OpenSSL reference')
-    t.end()
-})
+  var privateKeyPEM = ECPrivateKey8ASN.encode(
+    privateKeyObject,
+    "pem",
+    pemOptions
+  );
+  t.equal(
+    privateKeyPEM,
+    keys.pemPrivatePKCS8,
+    "encoded PEM private key should match the OpenSSL reference"
+  );
 
-test('encodeRawPrivateKey', function(t) {
-    var privateKeyPEM = keyEncoder.encodePrivate(keys.rawPrivate, 'raw', 'pem')
-    t.equal(typeof privateKeyPEM, "string")
-    t.equal(privateKeyPEM, keys.pemPrivate, 'encoded PEM private key should match the OpenSSL reference')
+  var decodedPrivateKeyObject = ECPrivateKey8ASN.decode(
+    privateKeyPEM,
+    "pem",
+    pemOptions
+  );
+  t.equal(
+    JSON.stringify(privateKeyObject),
+    JSON.stringify(decodedPrivateKeyObject),
+    "encoded-and-decoded private key object should match the original"
+  );
 
-    var privateKeyDER = keyEncoder.encodePrivate(keys.rawPrivate, 'raw', 'der')
-    t.equal(typeof privateKeyDER, "string")
-    t.equal(privateKeyDER, keys.derPrivate, 'encoded DER private key should match the OpenSSL reference')
-    t.end()
-})
+  var openSSLPrivateKeyObject = ECPrivateKey8ASN.decode(
+    keys.pemPrivatePKCS8,
+    "pem",
+    pemOptions
+  );
+  t.equal(
+    JSON.stringify(privateKeyObject),
+    JSON.stringify(openSSLPrivateKeyObject),
+    "private key object should match the one decoded from the OpenSSL PEM"
+  );
+  t.end();
+});
 
-test('encodeDERPrivateKey', function(t) {
-    var rawPrivateKey = keyEncoder.encodePrivate(keys.derPrivate, 'der', 'raw')
-    t.equal(typeof rawPrivateKey, "string")
-    t.equal(rawPrivateKey, keys.rawPrivate, 'encoded raw private key should match the OpenSSL reference')
+test("encodeSubjectPublicKeyInfoASN", function (t) {
+  var secp256k1Parameters = [1, 3, 132, 0, 10],
+    pemOptions = { label: "PUBLIC KEY" };
 
-    var privateKeyPEM = keyEncoder.encodePrivate(keys.derPrivate, 'der', 'pem')
-    t.equal(typeof privateKeyPEM, "string")
-    t.equal(privateKeyPEM, keys.pemPrivate, 'encoded PEM private key should match the OpenSSL reference')
-    t.end()
-})
+  var publicKeyObject = {
+    algorithm: {
+      id: [1, 2, 840, 10045, 2, 1],
+      curve: secp256k1Parameters,
+    },
+    pub: {
+      unused: 0,
+      data: Buffer.from(keys.rawPublic, "hex"),
+    },
+  };
 
-test('encodePEMPrivateKey', function(t) {
-    var rawPrivateKey = keyEncoder.encodePrivate(keys.pemPrivate, 'pem', 'raw')
-    t.equal(typeof rawPrivateKey, "string")
-    t.equal(rawPrivateKey, keys.rawPrivate, 'encoded raw private key should match the OpenSSL reference')
+  var publicKeyPEM = SubjectPublicKeyInfoASN.encode(
+    publicKeyObject,
+    "pem",
+    pemOptions
+  );
+  t.equal(typeof publicKeyPEM, "string");
+  t.equal(
+    publicKeyPEM,
+    keys.pemPublic,
+    "encoded PEM public key should match the OpenSSL reference"
+  );
+  t.end();
+});
 
-    var privateKeyDER = keyEncoder.encodePrivate(keys.pemPrivate, 'pem', 'der')
-    t.equal(typeof privateKeyDER, "string")
-    t.equal(privateKeyDER, keys.derPrivate, 'encoded DER private key should match the OpenSSL reference')
-    t.end()
-})
+test("encodeRawPrivateKey", function (t) {
+  var privateKeyPEM = keyEncoder.encodePrivate(keys.rawPrivate, "raw", "pem");
+  t.equal(typeof privateKeyPEM, "string");
+  t.equal(
+    privateKeyPEM,
+    keys.pemPrivate,
+    "encoded PEM private key should match the OpenSSL reference"
+  );
 
-test('encodeRawPublicKey', function(t) {
-    var publicKeyPEM = keyEncoder.encodePublic(keys.rawPublic, 'raw', 'pem')
-    t.equal(typeof publicKeyPEM, "string")
-    t.equal(publicKeyPEM, keys.pemPublic, 'encoded PEM public key should match the OpenSSL reference')
+  var privateKeyDER = keyEncoder.encodePrivate(keys.rawPrivate, "raw", "der");
+  t.equal(typeof privateKeyDER, "string");
+  t.equal(
+    privateKeyDER,
+    keys.derPrivate,
+    "encoded DER private key should match the OpenSSL reference"
+  );
+  t.end();
+});
 
-    var publicKeyDER = keyEncoder.encodePublic(keys.rawPublic, 'raw', 'der')
-    t.equal(typeof publicKeyDER, "string")
-    t.equal(publicKeyDER, keys.derPublic, 'encoded DER public key should match the OpenSSL reference')
-    t.end()
-})
+test("encodeDERPrivateKey", function (t) {
+  var rawPrivateKey = keyEncoder.encodePrivate(keys.derPrivate, "der", "raw");
+  t.equal(typeof rawPrivateKey, "string");
+  t.equal(
+    rawPrivateKey,
+    keys.rawPrivate,
+    "encoded raw private key should match the OpenSSL reference"
+  );
 
-test('encodeDERPublicKey', function(t) {
-    var rawPublicKey = keyEncoder.encodePublic(keys.derPublic, 'der', 'raw')
-    t.equal(typeof rawPublicKey, "string")
-    t.equal(rawPublicKey, keys.rawPublic, 'encoded raw public key should match the OpenSSL reference')
+  var privateKeyPEM = keyEncoder.encodePrivate(keys.derPrivate, "der", "pem");
+  t.equal(typeof privateKeyPEM, "string");
+  t.equal(
+    privateKeyPEM,
+    keys.pemPrivate,
+    "encoded PEM private key should match the OpenSSL reference"
+  );
+  t.end();
+});
 
-    var publicKeyPEM = keyEncoder.encodePublic(keys.derPublic, 'der', 'pem')
-    t.equal(typeof publicKeyPEM, "string")
-    t.equal(publicKeyPEM, keys.pemPublic, 'encoded PEM public key should match the OpenSSL reference')
-    t.end()
-})
+test("encodePEMPrivateKey", function (t) {
+  var rawPrivateKey = keyEncoder.encodePrivate(keys.pemPrivate, "pem", "raw");
+  t.equal(typeof rawPrivateKey, "string");
+  t.equal(
+    rawPrivateKey,
+    keys.rawPrivate,
+    "encoded raw private key should match the OpenSSL reference"
+  );
 
-test('encodePEMPublicKey', function(t) {
-    var rawPublicKey = keyEncoder.encodePublic(keys.pemPublic, 'pem', 'raw')
-    t.equal(typeof rawPublicKey, "string");
-    t.equal(rawPublicKey, keys.rawPublic, 'encoded raw public key should match the OpenSSL reference')
+  var privateKeyDER = keyEncoder.encodePrivate(keys.pemPrivate, "pem", "der");
+  t.equal(typeof privateKeyDER, "string");
+  t.equal(
+    privateKeyDER,
+    keys.derPrivate,
+    "encoded DER private key should match the OpenSSL reference"
+  );
+  t.end();
+});
 
-    var publicKeyDER = keyEncoder.encodePublic(keys.pemPublic, 'pem', 'der')
-    t.equal(typeof publicKeyDER, "string")
-    t.equal(publicKeyDER, keys.derPublic, 'encoded DER public key should match the OpenSSL reference')
-    t.end()
-})
+test("encodeRawPublicKey", function (t) {
+  var publicKeyPEM = keyEncoder.encodePublic(keys.rawPublic, "raw", "pem");
+  t.equal(typeof publicKeyPEM, "string");
+  t.equal(
+    publicKeyPEM,
+    keys.pemPublic,
+    "encoded PEM public key should match the OpenSSL reference"
+  );
+
+  var publicKeyDER = keyEncoder.encodePublic(keys.rawPublic, "raw", "der");
+  t.equal(typeof publicKeyDER, "string");
+  t.equal(
+    publicKeyDER,
+    keys.derPublic,
+    "encoded DER public key should match the OpenSSL reference"
+  );
+  t.end();
+});
+
+test("encodeDERPublicKey", function (t) {
+  var rawPublicKey = keyEncoder.encodePublic(keys.derPublic, "der", "raw");
+  t.equal(typeof rawPublicKey, "string");
+  t.equal(
+    rawPublicKey,
+    keys.rawPublic,
+    "encoded raw public key should match the OpenSSL reference"
+  );
+
+  var publicKeyPEM = keyEncoder.encodePublic(keys.derPublic, "der", "pem");
+  t.equal(typeof publicKeyPEM, "string");
+  t.equal(
+    publicKeyPEM,
+    keys.pemPublic,
+    "encoded PEM public key should match the OpenSSL reference"
+  );
+  t.end();
+});
+
+test("encodePEMPublicKey", function (t) {
+  var rawPublicKey = keyEncoder.encodePublic(keys.pemPublic, "pem", "raw");
+  t.equal(typeof rawPublicKey, "string");
+  t.equal(
+    rawPublicKey,
+    keys.rawPublic,
+    "encoded raw public key should match the OpenSSL reference"
+  );
+
+  var publicKeyDER = keyEncoder.encodePublic(keys.pemPublic, "pem", "der");
+  t.equal(typeof publicKeyDER, "string");
+  t.equal(
+    publicKeyDER,
+    keys.derPublic,
+    "encoded DER public key should match the OpenSSL reference"
+  );
+  t.end();
+});

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,110 +1,110 @@
-import * as test from "tape";
+import * as test from 'tape';
 // @ts-ignore
-import * as BN from "bn.js";
-import KeyEncoder from "./index";
+import * as BN from 'bn.js';
+import KeyEncoder from './index';
 const ECPrivateKeyASN = KeyEncoder.ECPrivateKeyASN;
 const ECPrivateKey8ASN = KeyEncoder.ECPrivateKey8ASN;
 const SubjectPublicKeyInfoASN = KeyEncoder.SubjectPublicKeyInfoASN;
 
 const keys = {
   rawPrivate:
-    "844055cca13efd78ce79a4c3a4c5aba5db0ebeb7ae9d56906c03d333c5668d5b",
+    '844055cca13efd78ce79a4c3a4c5aba5db0ebeb7ae9d56906c03d333c5668d5b',
   rawPublic:
-    "04147b79e9e1dd3324ceea115ff4037b6c877c73777131418bfb2b713effd0f502327b923861581bd5535eeae006765269f404f5f5c52214e9721b04aa7d040a75",
+    '04147b79e9e1dd3324ceea115ff4037b6c877c73777131418bfb2b713effd0f502327b923861581bd5535eeae006765269f404f5f5c52214e9721b04aa7d040a75',
   pemPrivate:
-    "-----BEGIN EC PRIVATE KEY-----\n" +
-    "MHQCAQEEIIRAVcyhPv14znmkw6TFq6XbDr63rp1WkGwD0zPFZo1boAcGBSuBBAAK\n" +
-    "oUQDQgAEFHt56eHdMyTO6hFf9AN7bId8c3dxMUGL+ytxPv/Q9QIye5I4YVgb1VNe\n" +
-    "6uAGdlJp9AT19cUiFOlyGwSqfQQKdQ==\n" +
-    "-----END EC PRIVATE KEY-----",
+    '-----BEGIN EC PRIVATE KEY-----\n' +
+    'MHQCAQEEIIRAVcyhPv14znmkw6TFq6XbDr63rp1WkGwD0zPFZo1boAcGBSuBBAAK\n' +
+    'oUQDQgAEFHt56eHdMyTO6hFf9AN7bId8c3dxMUGL+ytxPv/Q9QIye5I4YVgb1VNe\n' +
+    '6uAGdlJp9AT19cUiFOlyGwSqfQQKdQ==\n' +
+    '-----END EC PRIVATE KEY-----',
   pemPrivatePKCS8:
-    "-----BEGIN PRIVATE KEY-----\n" +
-    "MIGNAgEAMBAGByqGSM49AgEGBSuBBAAKBHYwdAIBAQQghEBVzKE+/XjOeaTDpMWr\n" +
-    "pdsOvreunVaQbAPTM8VmjVugBwYFK4EEAAqhRANCAAQUe3np4d0zJM7qEV/0A3ts\n" +
-    "h3xzd3ExQYv7K3E+/9D1AjJ7kjhhWBvVU17q4AZ2Umn0BPX1xSIU6XIbBKp9BAp1\n" +
-    "-----END PRIVATE KEY-----",
+    '-----BEGIN PRIVATE KEY-----\n' +
+    'MIGNAgEAMBAGByqGSM49AgEGBSuBBAAKBHYwdAIBAQQghEBVzKE+/XjOeaTDpMWr\n' +
+    'pdsOvreunVaQbAPTM8VmjVugBwYFK4EEAAqhRANCAAQUe3np4d0zJM7qEV/0A3ts\n' +
+    'h3xzd3ExQYv7K3E+/9D1AjJ7kjhhWBvVU17q4AZ2Umn0BPX1xSIU6XIbBKp9BAp1\n' +
+    '-----END PRIVATE KEY-----',
   pemCompactPrivate:
-    "-----BEGIN EC PRIVATE KEY-----\n" +
-    "MC4CAQEEIIRAVcyhPv14znmkw6TFq6XbDr63rp1WkGwD0zPFZo1boAcGBSuBBAAK\n" +
-    "-----END EC PRIVATE KEY-----",
+    '-----BEGIN EC PRIVATE KEY-----\n' +
+    'MC4CAQEEIIRAVcyhPv14znmkw6TFq6XbDr63rp1WkGwD0zPFZo1boAcGBSuBBAAK\n' +
+    '-----END EC PRIVATE KEY-----',
   pemPublic:
-    "-----BEGIN PUBLIC KEY-----\n" +
-    "MFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEFHt56eHdMyTO6hFf9AN7bId8c3dxMUGL\n" +
-    "+ytxPv/Q9QIye5I4YVgb1VNe6uAGdlJp9AT19cUiFOlyGwSqfQQKdQ==\n" +
-    "-----END PUBLIC KEY-----",
+    '-----BEGIN PUBLIC KEY-----\n' +
+    'MFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEFHt56eHdMyTO6hFf9AN7bId8c3dxMUGL\n' +
+    '+ytxPv/Q9QIye5I4YVgb1VNe6uAGdlJp9AT19cUiFOlyGwSqfQQKdQ==\n' +
+    '-----END PUBLIC KEY-----',
   derPrivate:
-    "30740201010420844055cca13efd78ce79a4c3a4c5aba5db0ebeb7ae9d56906c03d333c5668d5ba00706052b8104000aa14403420004147b79e9e1dd3324ceea115ff4037b6c877c73777131418bfb2b713effd0f502327b923861581bd5535eeae006765269f404f5f5c52214e9721b04aa7d040a75",
+    '30740201010420844055cca13efd78ce79a4c3a4c5aba5db0ebeb7ae9d56906c03d333c5668d5ba00706052b8104000aa14403420004147b79e9e1dd3324ceea115ff4037b6c877c73777131418bfb2b713effd0f502327b923861581bd5535eeae006765269f404f5f5c52214e9721b04aa7d040a75',
   derPrivatePKCS8:
-    "30818d020100301006072a8648ce3d020106052b8104000a047630740201010420 844055cca13efd78ce79a4c3a4c5aba5db0ebeb7ae9d56906c03d333c5668d5ba00706052b8104000aa14403420004147b79e9e1dd3324ceea115ff4037b6c877c73777131418bfb2b713effd0f502327b923861581bd5535eeae006765269f404f5f5c52214e9721b04aa7d040a75",
+    '30818d020100301006072a8648ce3d020106052b8104000a047630740201010420 844055cca13efd78ce79a4c3a4c5aba5db0ebeb7ae9d56906c03d333c5668d5ba00706052b8104000aa14403420004147b79e9e1dd3324ceea115ff4037b6c877c73777131418bfb2b713effd0f502327b923861581bd5535eeae006765269f404f5f5c52214e9721b04aa7d040a75',
   derPublic:
-    "3056301006072a8648ce3d020106052b8104000a03420004147b79e9e1dd3324ceea115ff4037b6c877c73777131418bfb2b713effd0f502327b923861581bd5535eeae006765269f404f5f5c52214e9721b04aa7d040a75",
+    '3056301006072a8648ce3d020106052b8104000a03420004147b79e9e1dd3324ceea115ff4037b6c877c73777131418bfb2b713effd0f502327b923861581bd5535eeae006765269f404f5f5c52214e9721b04aa7d040a75',
 };
 
-const keyEncoder = new KeyEncoder("secp256k1");
+const keyEncoder = new KeyEncoder('secp256k1');
 
-test("encodeECPrivateKeyASN", function (t) {
+test('encodeECPrivateKeyASN', function (t) {
   var secp256k1Parameters = [1, 3, 132, 0, 10],
-    pemOptions = { label: "EC PRIVATE KEY" };
+    pemOptions = { label: 'EC PRIVATE KEY' };
 
   var privateKeyObject = {
     version: new BN(1),
-    privateKey: Buffer.from(keys.rawPrivate, "hex"),
+    privateKey: Buffer.from(keys.rawPrivate, 'hex'),
     parameters: secp256k1Parameters,
-    publicKey: { unused: 0, data: Buffer.from(keys.rawPublic, "hex") },
+    publicKey: { unused: 0, data: Buffer.from(keys.rawPublic, 'hex') },
   };
 
   var privateKeyPEM = ECPrivateKeyASN.encode(
     privateKeyObject,
-    "pem",
+    'pem',
     pemOptions
   );
   t.equal(
     privateKeyPEM,
     keys.pemPrivate,
-    "encoded PEM private key should match the OpenSSL reference"
+    'encoded PEM private key should match the OpenSSL reference'
   );
 
   var decodedPrivateKeyObject = ECPrivateKeyASN.decode(
     privateKeyPEM,
-    "pem",
+    'pem',
     pemOptions
   );
   t.equal(
     JSON.stringify(privateKeyObject),
     JSON.stringify(decodedPrivateKeyObject),
-    "encoded-and-decoded private key object should match the original"
+    'encoded-and-decoded private key object should match the original'
   );
 
   var openSSLPrivateKeyObject = ECPrivateKeyASN.decode(
     keys.pemPrivate,
-    "pem",
+    'pem',
     pemOptions
   );
   t.equal(
     JSON.stringify(privateKeyObject),
     JSON.stringify(openSSLPrivateKeyObject),
-    "private key object should match the one decoded from the OpenSSL PEM"
+    'private key object should match the one decoded from the OpenSSL PEM'
   );
   t.end();
 });
 
-test("encodeECPrivateKey8ASN", function (t) {
+test('encodeECPrivateKey8ASN', function (t) {
   var secp256k1Parameters = [1, 3, 132, 0, 10],
-    pemOptions = { label: "PRIVATE KEY" };
+    pemOptions = { label: 'PRIVATE KEY' };
 
   var privateKey = {
     version: new BN(1),
-    privateKey: Buffer.from(keys.rawPrivate, "hex"),
+    privateKey: Buffer.from(keys.rawPrivate, 'hex'),
     parameters: secp256k1Parameters,
-    publicKey: { unused: 0, data: Buffer.from(keys.rawPublic, "hex") },
+    publicKey: { unused: 0, data: Buffer.from(keys.rawPublic, 'hex') },
   };
   var asString = JSON.stringify(privateKey);
   var test1 = Buffer.from(
     asString
-      .split("")
+      .split('')
       .map((x) => (256 + x.charCodeAt(0)).toString(16).substr(-2))
-      .join(""),
-    "hex"
+      .join(''),
+    'hex'
   );
   var privateKeyObject = {
     version: new BN(0),
@@ -117,42 +117,42 @@ test("encodeECPrivateKey8ASN", function (t) {
 
   var privateKeyPEM = ECPrivateKey8ASN.encode(
     privateKeyObject,
-    "pem",
+    'pem',
     pemOptions
   );
   t.equal(
     privateKeyPEM,
     keys.pemPrivatePKCS8,
-    "encoded PEM private key should match the OpenSSL reference"
+    'encoded PEM private key should match the OpenSSL reference'
   );
 
   var decodedPrivateKeyObject = ECPrivateKey8ASN.decode(
     privateKeyPEM,
-    "pem",
+    'pem',
     pemOptions
   );
   t.equal(
     JSON.stringify(privateKeyObject),
     JSON.stringify(decodedPrivateKeyObject),
-    "encoded-and-decoded private key object should match the original"
+    'encoded-and-decoded private key object should match the original'
   );
 
   var openSSLPrivateKeyObject = ECPrivateKey8ASN.decode(
     keys.pemPrivatePKCS8,
-    "pem",
+    'pem',
     pemOptions
   );
   t.equal(
     JSON.stringify(privateKeyObject),
     JSON.stringify(openSSLPrivateKeyObject),
-    "private key object should match the one decoded from the OpenSSL PEM"
+    'private key object should match the one decoded from the OpenSSL PEM'
   );
   t.end();
 });
 
-test("encodeSubjectPublicKeyInfoASN", function (t) {
+test('encodeSubjectPublicKeyInfoASN', function (t) {
   var secp256k1Parameters = [1, 3, 132, 0, 10],
-    pemOptions = { label: "PUBLIC KEY" };
+    pemOptions = { label: 'PUBLIC KEY' };
 
   var publicKeyObject = {
     algorithm: {
@@ -161,134 +161,134 @@ test("encodeSubjectPublicKeyInfoASN", function (t) {
     },
     pub: {
       unused: 0,
-      data: Buffer.from(keys.rawPublic, "hex"),
+      data: Buffer.from(keys.rawPublic, 'hex'),
     },
   };
 
   var publicKeyPEM = SubjectPublicKeyInfoASN.encode(
     publicKeyObject,
-    "pem",
+    'pem',
     pemOptions
   );
-  t.equal(typeof publicKeyPEM, "string");
+  t.equal(typeof publicKeyPEM, 'string');
   t.equal(
     publicKeyPEM,
     keys.pemPublic,
-    "encoded PEM public key should match the OpenSSL reference"
+    'encoded PEM public key should match the OpenSSL reference'
   );
   t.end();
 });
 
-test("encodeRawPrivateKey", function (t) {
-  var privateKeyPEM = keyEncoder.encodePrivate(keys.rawPrivate, "raw", "pem");
-  t.equal(typeof privateKeyPEM, "string");
+test('encodeRawPrivateKey', function (t) {
+  var privateKeyPEM = keyEncoder.encodePrivate(keys.rawPrivate, 'raw', 'pem');
+  t.equal(typeof privateKeyPEM, 'string');
   t.equal(
     privateKeyPEM,
     keys.pemPrivate,
-    "encoded PEM private key should match the OpenSSL reference"
+    'encoded PEM private key should match the OpenSSL reference'
   );
 
-  var privateKeyDER = keyEncoder.encodePrivate(keys.rawPrivate, "raw", "der");
-  t.equal(typeof privateKeyDER, "string");
+  var privateKeyDER = keyEncoder.encodePrivate(keys.rawPrivate, 'raw', 'der');
+  t.equal(typeof privateKeyDER, 'string');
   t.equal(
     privateKeyDER,
     keys.derPrivate,
-    "encoded DER private key should match the OpenSSL reference"
+    'encoded DER private key should match the OpenSSL reference'
   );
   t.end();
 });
 
-test("encodeDERPrivateKey", function (t) {
-  var rawPrivateKey = keyEncoder.encodePrivate(keys.derPrivate, "der", "raw");
-  t.equal(typeof rawPrivateKey, "string");
+test('encodeDERPrivateKey', function (t) {
+  var rawPrivateKey = keyEncoder.encodePrivate(keys.derPrivate, 'der', 'raw');
+  t.equal(typeof rawPrivateKey, 'string');
   t.equal(
     rawPrivateKey,
     keys.rawPrivate,
-    "encoded raw private key should match the OpenSSL reference"
+    'encoded raw private key should match the OpenSSL reference'
   );
 
-  var privateKeyPEM = keyEncoder.encodePrivate(keys.derPrivate, "der", "pem");
-  t.equal(typeof privateKeyPEM, "string");
+  var privateKeyPEM = keyEncoder.encodePrivate(keys.derPrivate, 'der', 'pem');
+  t.equal(typeof privateKeyPEM, 'string');
   t.equal(
     privateKeyPEM,
     keys.pemPrivate,
-    "encoded PEM private key should match the OpenSSL reference"
+    'encoded PEM private key should match the OpenSSL reference'
   );
   t.end();
 });
 
-test("encodePEMPrivateKey", function (t) {
-  var rawPrivateKey = keyEncoder.encodePrivate(keys.pemPrivate, "pem", "raw");
-  t.equal(typeof rawPrivateKey, "string");
+test('encodePEMPrivateKey', function (t) {
+  var rawPrivateKey = keyEncoder.encodePrivate(keys.pemPrivate, 'pem', 'raw');
+  t.equal(typeof rawPrivateKey, 'string');
   t.equal(
     rawPrivateKey,
     keys.rawPrivate,
-    "encoded raw private key should match the OpenSSL reference"
+    'encoded raw private key should match the OpenSSL reference'
   );
 
-  var privateKeyDER = keyEncoder.encodePrivate(keys.pemPrivate, "pem", "der");
-  t.equal(typeof privateKeyDER, "string");
+  var privateKeyDER = keyEncoder.encodePrivate(keys.pemPrivate, 'pem', 'der');
+  t.equal(typeof privateKeyDER, 'string');
   t.equal(
     privateKeyDER,
     keys.derPrivate,
-    "encoded DER private key should match the OpenSSL reference"
+    'encoded DER private key should match the OpenSSL reference'
   );
   t.end();
 });
 
-test("encodeRawPublicKey", function (t) {
-  var publicKeyPEM = keyEncoder.encodePublic(keys.rawPublic, "raw", "pem");
-  t.equal(typeof publicKeyPEM, "string");
+test('encodeRawPublicKey', function (t) {
+  var publicKeyPEM = keyEncoder.encodePublic(keys.rawPublic, 'raw', 'pem');
+  t.equal(typeof publicKeyPEM, 'string');
   t.equal(
     publicKeyPEM,
     keys.pemPublic,
-    "encoded PEM public key should match the OpenSSL reference"
+    'encoded PEM public key should match the OpenSSL reference'
   );
 
-  var publicKeyDER = keyEncoder.encodePublic(keys.rawPublic, "raw", "der");
-  t.equal(typeof publicKeyDER, "string");
+  var publicKeyDER = keyEncoder.encodePublic(keys.rawPublic, 'raw', 'der');
+  t.equal(typeof publicKeyDER, 'string');
   t.equal(
     publicKeyDER,
     keys.derPublic,
-    "encoded DER public key should match the OpenSSL reference"
+    'encoded DER public key should match the OpenSSL reference'
   );
   t.end();
 });
 
-test("encodeDERPublicKey", function (t) {
-  var rawPublicKey = keyEncoder.encodePublic(keys.derPublic, "der", "raw");
-  t.equal(typeof rawPublicKey, "string");
+test('encodeDERPublicKey', function (t) {
+  var rawPublicKey = keyEncoder.encodePublic(keys.derPublic, 'der', 'raw');
+  t.equal(typeof rawPublicKey, 'string');
   t.equal(
     rawPublicKey,
     keys.rawPublic,
-    "encoded raw public key should match the OpenSSL reference"
+    'encoded raw public key should match the OpenSSL reference'
   );
 
-  var publicKeyPEM = keyEncoder.encodePublic(keys.derPublic, "der", "pem");
-  t.equal(typeof publicKeyPEM, "string");
+  var publicKeyPEM = keyEncoder.encodePublic(keys.derPublic, 'der', 'pem');
+  t.equal(typeof publicKeyPEM, 'string');
   t.equal(
     publicKeyPEM,
     keys.pemPublic,
-    "encoded PEM public key should match the OpenSSL reference"
+    'encoded PEM public key should match the OpenSSL reference'
   );
   t.end();
 });
 
-test("encodePEMPublicKey", function (t) {
-  var rawPublicKey = keyEncoder.encodePublic(keys.pemPublic, "pem", "raw");
-  t.equal(typeof rawPublicKey, "string");
+test('encodePEMPublicKey', function (t) {
+  var rawPublicKey = keyEncoder.encodePublic(keys.pemPublic, 'pem', 'raw');
+  t.equal(typeof rawPublicKey, 'string');
   t.equal(
     rawPublicKey,
     keys.rawPublic,
-    "encoded raw public key should match the OpenSSL reference"
+    'encoded raw public key should match the OpenSSL reference'
   );
 
-  var publicKeyDER = keyEncoder.encodePublic(keys.pemPublic, "pem", "der");
-  t.equal(typeof publicKeyDER, "string");
+  var publicKeyDER = keyEncoder.encodePublic(keys.pemPublic, 'pem', 'der');
+  t.equal(typeof publicKeyDER, 'string');
   t.equal(
     publicKeyDER,
     keys.derPublic,
-    "encoded DER public key should match the OpenSSL reference"
+    'encoded DER public key should match the OpenSSL reference'
   );
   t.end();
 });

--- a/src/test.ts
+++ b/src/test.ts
@@ -28,14 +28,14 @@ const keys = {
     '-----END PUBLIC KEY-----',
     derPrivate: '30740201010420844055cca13efd78ce79a4c3a4c5aba5db0ebeb7ae9d56906c03d333c5668d5ba00706052b8104000aa14403420004147b79e9e1dd3324ceea115ff4037b6c877c73777131418bfb2b713effd0f502327b923861581bd5535eeae006765269f404f5f5c52214e9721b04aa7d040a75',
     derPrivatePKCS8: '30818d020100301006072a8648ce3d020106052b8104000a047630740201010420 844055cca13efd78ce79a4c3a4c5aba5db0ebeb7ae9d56906c03d333c5668d5ba00706052b8104000aa14403420004147b79e9e1dd3324ceea115ff4037b6c877c73777131418bfb2b713effd0f502327b923861581bd5535eeae006765269f404f5f5c52214e9721b04aa7d040a75',
-    derPublic: '3056301006072a8648ce3d020106052b8104000a03420004147b79e9e1dd3324ceea115ff4037b6c877c73777131418bfb2b713effd0f502327b923861581bd5535eeae006765269f404f5f5c52214e9721b04aa7d040a75',
+    derPublic: '3056301006072a8648ce3d020106052b8104000a03420004147b79e9e1dd3324ceea115ff4037b6c877c73777131418bfb2b713effd0f502327b923861581bd5535eeae006765269f404f5f5c52214e9721b04aa7d040a75'
 }
 
 const keyEncoder = new KeyEncoder('secp256k1')
 
 test('encodeECPrivateKeyASN', function(t) {
     var secp256k1Parameters = [1, 3, 132, 0, 10],
-        pemOptions = {label: 'EC PRIVATE KEY'}
+        pemOptions =  {label: 'EC PRIVATE KEY'}
 
     var privateKeyObject = {
         version: new BN(1),
@@ -57,7 +57,7 @@ test('encodeECPrivateKeyASN', function(t) {
 
 test('encodeECPrivateKey8ASN', function(t) {
     var secp256k1Parameters = [1, 3, 132, 0, 10],
-        pemOptions = {label: 'PRIVATE KEY'}
+        pemOptions =  {label: 'PRIVATE KEY'}
 
     var privateKey = {
         version: new BN(1),
@@ -65,14 +65,6 @@ test('encodeECPrivateKey8ASN', function(t) {
         parameters: secp256k1Parameters,
         publicKey: { unused: 0, data: Buffer.from(keys.rawPublic, 'hex') }
     }
-    var asString = JSON.stringify(privateKey)
-    var test1 = Buffer.from(
-        asString
-            .split('')
-            .map((x) => (256 + x.charCodeAt(0)).toString(16).substr(-2))
-            .join(''),
-        'hex'
-    )
     var privateKeyObject = {
         version: new BN(0),
         privateKeyAlgorithm: {
@@ -95,7 +87,7 @@ test('encodeECPrivateKey8ASN', function(t) {
 
 test('encodeSubjectPublicKeyInfoASN', function(t) {
     var secp256k1Parameters = [1, 3, 132, 0, 10],
-        pemOptions = {label: 'PUBLIC KEY'}
+        pemOptions =  {label: 'PUBLIC KEY'}
 
     var publicKeyObject = {
         algorithm: {
@@ -109,73 +101,73 @@ test('encodeSubjectPublicKeyInfoASN', function(t) {
     }
 
     var publicKeyPEM = SubjectPublicKeyInfoASN.encode(publicKeyObject, 'pem', pemOptions)
-    t.equal(typeof publicKeyPEM, 'string')
+    t.equal(typeof publicKeyPEM, "string")
     t.equal(publicKeyPEM, keys.pemPublic, 'encoded PEM public key should match the OpenSSL reference')
     t.end()
 })
 
 test('encodeRawPrivateKey', function(t) {
     var privateKeyPEM = keyEncoder.encodePrivate(keys.rawPrivate, 'raw', 'pem')
-    t.equal(typeof privateKeyPEM, 'string')
+    t.equal(typeof privateKeyPEM, "string")
     t.equal(privateKeyPEM, keys.pemPrivate, 'encoded PEM private key should match the OpenSSL reference')
 
     var privateKeyDER = keyEncoder.encodePrivate(keys.rawPrivate, 'raw', 'der')
-    t.equal(typeof privateKeyDER, 'string')
-    t.equal(privateKeyDER,keys.derPrivate, 'encoded DER private key should match the OpenSSL reference')
+    t.equal(typeof privateKeyDER, "string")
+    t.equal(privateKeyDER, keys.derPrivate, 'encoded DER private key should match the OpenSSL reference')
     t.end()
 })
 
 test('encodeDERPrivateKey', function(t) {
     var rawPrivateKey = keyEncoder.encodePrivate(keys.derPrivate, 'der', 'raw')
-    t.equal(typeof rawPrivateKey, 'string')
+    t.equal(typeof rawPrivateKey, "string")
     t.equal(rawPrivateKey, keys.rawPrivate, 'encoded raw private key should match the OpenSSL reference')
 
     var privateKeyPEM = keyEncoder.encodePrivate(keys.derPrivate, 'der', 'pem')
-    t.equal(typeof privateKeyPEM, 'string')
+    t.equal(typeof privateKeyPEM, "string")
     t.equal(privateKeyPEM, keys.pemPrivate, 'encoded PEM private key should match the OpenSSL reference')
     t.end()
 })
 
 test('encodePEMPrivateKey', function(t) {
     var rawPrivateKey = keyEncoder.encodePrivate(keys.pemPrivate, 'pem', 'raw')
-    t.equal(typeof rawPrivateKey, 'string')
+    t.equal(typeof rawPrivateKey, "string")
     t.equal(rawPrivateKey, keys.rawPrivate, 'encoded raw private key should match the OpenSSL reference')
 
     var privateKeyDER = keyEncoder.encodePrivate(keys.pemPrivate, 'pem', 'der')
-    t.equal(typeof privateKeyDER, 'string')
-    t.equal(privateKeyDER,keys.derPrivate, 'encoded DER private key should match the OpenSSL reference')
+    t.equal(typeof privateKeyDER, "string")
+    t.equal(privateKeyDER, keys.derPrivate, 'encoded DER private key should match the OpenSSL reference')
     t.end()
 })
 
 test('encodeRawPublicKey', function(t) {
     var publicKeyPEM = keyEncoder.encodePublic(keys.rawPublic, 'raw', 'pem')
-    t.equal(typeof publicKeyPEM, 'string')
+    t.equal(typeof publicKeyPEM, "string")
     t.equal(publicKeyPEM, keys.pemPublic, 'encoded PEM public key should match the OpenSSL reference')
 
     var publicKeyDER = keyEncoder.encodePublic(keys.rawPublic, 'raw', 'der')
-    t.equal(typeof publicKeyDER, 'string')
+    t.equal(typeof publicKeyDER, "string")
     t.equal(publicKeyDER, keys.derPublic, 'encoded DER public key should match the OpenSSL reference')
     t.end()
 })
 
 test('encodeDERPublicKey', function(t) {
     var rawPublicKey = keyEncoder.encodePublic(keys.derPublic, 'der', 'raw')
-    t.equal(typeof rawPublicKey, 'string')
+    t.equal(typeof rawPublicKey, "string")
     t.equal(rawPublicKey, keys.rawPublic, 'encoded raw public key should match the OpenSSL reference')
 
     var publicKeyPEM = keyEncoder.encodePublic(keys.derPublic, 'der', 'pem')
-    t.equal(typeof publicKeyPEM, 'string')
+    t.equal(typeof publicKeyPEM, "string")
     t.equal(publicKeyPEM, keys.pemPublic, 'encoded PEM public key should match the OpenSSL reference')
     t.end()
 })
 
 test('encodePEMPublicKey', function(t) {
     var rawPublicKey = keyEncoder.encodePublic(keys.pemPublic, 'pem', 'raw')
-    t.equal(typeof rawPublicKey, 'string')
+    t.equal(typeof rawPublicKey, "string")
     t.equal(rawPublicKey, keys.rawPublic, 'encoded raw public key should match the OpenSSL reference')
 
     var publicKeyDER = keyEncoder.encodePublic(keys.pemPublic, 'pem', 'der')
-    t.equal(typeof publicKeyDER, 'string')
+    t.equal(typeof publicKeyDER, "string")
     t.equal(publicKeyDER, keys.derPublic, 'encoded DER public key should match the OpenSSL reference')
     t.end()
 })


### PR DESCRIPTION
## Description

As a developer, I would like export the private key in PKCS #8. This is needed because some libraries accept only this format. This pull request adds the `PrivateKeyPKCS8` interface which describe the structure of PKCS #8.

```ts
interface PrivateKeyPKCS8 {
  version: BNjs;
  privateKey: PrivateKeyPKCS1;
  privateKeyAlgorithm: { ecPublicKey: number[]; curve: number[] };
}
```

## Type of Change
- [x] New feature
- [ ] Bug fix
- [x] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
<!-- 
  DOCUMENTATION
  Consider if this PR makes changes that require documentation updates:
    - API changes
    - Renamed methods
    - Change in instructions inside tutorials/guides
    - etc...

   The best way to find these is by searching inside the docs at https://github.com/blockstack/docs
-->
- Changed interface name from 'PrivateKey' to 'PrivateKeyPKCS1';
- Added default parameter 'destinationFormatType' in 'encodePrivate' function.

## Testing information

Tests added.

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [x] Changelog is updated
- [ ] Tag 1 of @person1 or @person2 (??? @zone117x )
